### PR TITLE
Better checking of nested models in pool.compare

### DIFF
--- a/R/pool.compare.r
+++ b/R/pool.compare.r
@@ -132,6 +132,8 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     vars1 = names(est1$qbar)
     vars0 = names(est0$qbar)
     
+    if (is.null(vars1) | is.null(vars0)) 
+      stop("coefficients do not have names")
     if (dimQ2 < 1) 
         stop("The larger model should be specified first and must be strictly larger than the smaller model.\n")
     if (!setequal(vars0, intersect(vars0, vars1))) 

--- a/R/pool.compare.r
+++ b/R/pool.compare.r
@@ -127,6 +127,8 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     dimQ1 <- length(est1$qbar)
     dimQ2 <- dimQ1 - length(est0$qbar)
     # Check: Only need the lm or lmer object
+    formula1 <- formula(fit1$analyses[[1]])
+    formula0 <- formula(fit0$analyses[[1]])
     vars1 = names(est1$qbar)
     vars0 = names(est0$qbar)
     

--- a/R/pool.compare.r
+++ b/R/pool.compare.r
@@ -127,21 +127,20 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     dimQ1 <- length(est1$qbar)
     dimQ2 <- dimQ1 - length(est0$qbar)
     # Check: Only need the lm or lmer object
-    formula1 <- formula(fit1$analyses[[1]])
-    formula0 <- formula(fit0$analyses[[1]])
+    vars1 = names(est1$qbar)
+    vars0 = names(est0$qbar)
     
     if (dimQ2 < 1) 
         stop("The larger model should be specified first and must be strictly larger than the smaller model.\n")
-    if (!setequal(all.vars(formula0), intersect(all.vars(formula0), all.vars(formula1)))) 
+    if (!setequal(vars0, intersect(vars0, vars1))) 
         stop("The smaller model should be fully contained in the larger model. \n")
-    if (!all(charmatch(all.vars(formula0), all.vars(formula1)) == (1:length(all.vars(formula0))))) 
-        stop("The first variables of the larger model should be the variables of the smaller model in the same order.\n")
     
     if (meth == "wald") {
         # Reference: paragraph 2.2, Article Meng & Rubin, Biometrika, 1992.  When two objects are to be compared we need to
         # calculate the matrix Q.
         Q <- diag(rep(1, dimQ1), ncol = dimQ1)
-        Q <- matrix(Q[((dimQ1 - dimQ2 + 1):dimQ1), ], nrow = dimQ2, ncol = dimQ1)
+        where_new_vars = which(!(vars1 %in% vars0))
+        Q <- Q[where_new_vars, , drop = FALSE]
         qbar <- Q %*% est1$qbar
         Ubar <- Q %*% est1$ubar %*% (t(Q))
         Bm <- Q %*% est1$b %*% (t(Q))


### PR DESCRIPTION
With the current implementation of `pool.compare`, the formulas of the nested models have to be in the correct order. Specifically, any new variables have to be the last parts of the formula. I wanted to improve this because it is not always straightforward to do and I found a case where the current implementation does not work as intended. 

For example, if there are interactions, the model matrix that is created may not order the variable the same way as the formula. The interaction terms are added at the end of the model matrix, regardless of where they are in the formula.

The following code will produce an incorrect result and will not give an error. It will test the significance of the interaction `x1:x2`.

```
fit0 <- with(imp, lm(y ~ x1 * x2))
fit1 <- with(imp, lm(y ~ x1 * x2 + x3))
pool.compare(fit1, fit0)$pvalue
```

I have changed the code to check the names of the coefficients instead of the using the formulas. This obviously assumes that the coefficients have names, but I have tested it and they do for `lm`, `glm`, and `lmer` objects.

With the new function, the order of the variables doesn't matter, as long as the models are nested. The following will work fine, correctly identifying `x3` and `x5` are the new variables.

```
fit0 <- with(imp, lm(y ~ x4 + x1 * x2))
fit1 <- with(imp, lm(y ~ x3 + x1 * x2 + x5 + x4))
pool.compare(fit1, fit0)$pvalue
```
