### PR TITLE
various minor changes for efficiency and robustness

### DIFF
--- a/R/Ampute.R
+++ b/R/Ampute.R
@@ -230,10 +230,9 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # #missing cells. 
     miss <- prop * n^2  # Desired #missing cells 
     # Calculate #cases according prop and #zeros in patterns
-    cases <- numeric(nrow(patterns))
-    for (i in seq_along(cases)) {
-      cases[i] <- (miss * freq[i]) / length(patterns[i,][patterns[i,] == 0]) 
-    }
+    cases <- vapply(seq_len(nrow(patterns)),
+                    function(i) (miss * freq[i]) / length(patterns[i,][patterns[i,] == 0]),
+                    numeric(1))
     if (sum(cases) > n) {
       stop("Proportion of missing cells is too large in combination with 
            the desired number of missing variables",
@@ -443,7 +442,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   }
   if (!cont) {
     for (h in seq_len(nrow(odds))) {
-      if(any(!is.na(odds[h, ]) && odds[h, ] < 0)) {
+      if(any(!is.na(odds[h, ]) & odds[h, ] < 0)) {
         stop("Odds matrix can only have positive values", call. = FALSE)
       }
     }

--- a/R/Ampute.R
+++ b/R/Ampute.R
@@ -464,7 +464,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # Assign cases to the patterns according probs
     # Because 0 and 1 will be used for missingness, 
     # the numbering of the patterns will start from 2
-    P <- sample.int(x = nrow(patterns.new), size = nrow(data), 
+    P <- sample.int(n = nrow(patterns.new), size = nrow(data), 
                 replace = TRUE, prob = freq) + 1
     # Calculate missingness according MCAR or calculate weighted sum scores
     # Standardized data is used to calculate weighted sum scores

--- a/R/Ampute.R
+++ b/R/Ampute.R
@@ -207,17 +207,18 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # The calculation of the probabilities occur in the function ampute.mcar(), 
     # ampute.continuous() or ampute.discrete(), based on the kind of missingness. 
     weights <- as.matrix(weights)
-    scores <- list()
-    for (i in 1:nrow(patterns)) {
+    
+    f <- function(i) {
       if (length(P[P == (i + 1)]) == 0) {
-        scores[[i]] <- 0
+        return(0)
       } else {
         candidates <- as.matrix(data[P == (i + 1), ])
         # For each candidate in the pattern, a weighted sum score is calculated
-        scores[[i]] <- apply(candidates, 1, 
-                             function(x) weights[i, ] %*% x)
+        return(apply(candidates, 1, function(x) weights[i, ] %*% x))
       }
     }
+    
+    scores <- lapply(seq_len(nrow(patterns)), f)
     return(scores)
   }
   #
@@ -229,9 +230,9 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # #missing cells. 
     miss <- prop * n^2  # Desired #missing cells 
     # Calculate #cases according prop and #zeros in patterns
-    cases <- c()
-    for (i in 1:nrow(patterns)) {
-      cases [i] <- (miss * freq[i]) / length(patterns[i,][patterns[i,] == 0]) 
+    cases <- numeric(nrow(patterns))
+    for (i in seq_along(cases)) {
+      cases[i] <- (miss * freq[i]) / length(patterns[i,][patterns[i,] == 0]) 
     }
     if (sum(cases) > n) {
       stop("Proportion of missing cells is too large in combination with 
@@ -248,11 +249,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   recalculate.freq <- function(freq) {
     # This is an underlying function of multivariate amputation function ampute().
     # The function recalculates the frequency vector to make the sum equal to 1. 
-    s <- sum(freq)
-    for (p in 1:length(freq)) {
-      freq[p] <- freq[p] / s
-    }
-    return(freq)
+    return(freq / sum(freq))
   }
   #
   # -------------------------  check.patterns ---------------------------------
@@ -265,7 +262,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # this is ascertained and saved in the object row.zero. 
     prop.one <- 0
     row.one <- c()
-    for (h in 1:nrow(patterns)) {
+    for (h in seq_len(nrow(patterns))) {
       if (any(!patterns[h, ] %in% c(0, 1))) {
         stop(paste("Argument patterns can only contain 0 and 1, pattern", h, 
                    "contains another element"), call. = FALSE)
@@ -287,7 +284,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     }
     prop.zero <- 0
     row.zero <- c()
-    for (h in 1:nrow(patterns)) {
+    for (h in seq_len(nrow(patterns))) {
       if (all(patterns[h, ] %in% 0)) {
         prop.zero <- prop.zero + freq[h]
         row.zero <- c(row.zero, h)
@@ -305,16 +302,16 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (is.null(data)) {
     stop("Argument data is missing, with no default", call. = FALSE)
   }
-  if (!(is.matrix(data) | is.data.frame(data))) {
+  if (!(is.matrix(data) || is.data.frame(data))) {
     stop("Data should be a matrix or data frame", call. = FALSE)
   }
-  if (any(sapply(data, is.na))) {
+  if (anyNA(data)) {
     stop("Data cannot contain NAs", call. = FALSE)
   }
   if (ncol(data) < 2) {
     stop("Data should contain at least two columns", call. = FALSE)
   } 
-  if (any(sapply(data, is.numeric) == FALSE) & mech != "MCAR") {
+  if (any(vapply(data, Negate(is.numeric), logical(1))) && mech != "MCAR") {
     data <- as.data.frame(sapply(data, as.numeric))
     warning("Data is made numeric because the calculation of weights requires 
             numeric data",
@@ -322,7 +319,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   }
   data <- data.frame(data)
   st.data <- data.frame(scale(data))
-  if (prop < 0 | prop > 100) {
+  if (prop < 0 || prop > 100) {
     stop("Proportion of missingness should be a value between 0 and 1 
          (for a proportion) or between 1 and 100 (for a percentage)", call. = FALSE)
   } else if (prop > 1) {
@@ -330,9 +327,9 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   }
   if (is.null(patterns)) {
     patterns <- ampute.default.patterns(n = ncol(data))
-  } else if (is.vector(patterns) & (length(patterns) / ncol(data)) %% 1 == 0) {
+  } else if (is.vector(patterns) && (length(patterns) / ncol(data)) %% 1 == 0) {
     patterns <- matrix(patterns, length(patterns) / ncol(data), byrow = TRUE)
-    if (nrow(patterns) == 1 & all(patterns[1, ] %in% 1)) {
+    if (nrow(patterns) == 1 && all(patterns[1, ] %in% 1)) {
       stop("One pattern with merely ones results to no amputation at all, the 
            procedure is therefore stopped", call. = FALSE)
     }
@@ -352,9 +349,9 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   }
   if (length(freq) != nrow(patterns)) {
     if (length(freq) > nrow(patterns)) {
-      freq <- freq[1:length(nrow(patterns))]
+      freq <- freq[seq_along(nrow(patterns))]
     } else {
-      freq <- c(freq, rep(0.2, nrow(patterns) - length(freq)))
+      freq <- c(freq, rep.int(0.2, nrow(patterns) - length(freq)))
     }
       warning(paste("Length of vector with relative frequencies does not match 
       #patterns and is therefore changed to", freq), call. = FALSE)
@@ -362,7 +359,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (sum(freq) != 1) {
     freq <- recalculate.freq(freq = freq)
   }
-  if (bycases == FALSE) {
+  if (!bycases) {
     prop <- recalculate.prop(prop = prop, 
                              freq = freq,
                              patterns = patterns,
@@ -385,13 +382,13 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
       warning("Mechanism should contain merely MCAR, MAR or MNAR. First element is used", 
               call. = FALSE)
   }
-  if (mech == "MCAR" & !is.null(weights)) {
+  if (mech == "MCAR" && !is.null(weights)) {
     warning("Weights matrix is not used when mechanism is MCAR", call. = FALSE)
   }
-  if (mech == "MCAR" & !is.null(odds)) {
+  if (mech == "MCAR" && !is.null(odds)) {
     warning("Odds matrix is not used when mechanism is MCAR", call. = FALSE)
   }
-  if (mech != "MCAR" & !is.null(weights)) {
+  if (mech != "MCAR" && !is.null(weights)) {
     if (is.vector(weights) & (length(weights) / ncol(data)) %% 1 == 0) {
       weights <- matrix(weights, length(weights) / ncol(data), byrow = TRUE)
     } else if (is.vector(weights)) {
@@ -415,11 +412,11 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (!is.logical(cont)) {
     stop("Continuous should contain TRUE or FALSE", call. = FALSE)
   }
-  if (cont == TRUE & !is.null(odds)) {
+  if (cont && !is.null(odds)) {
     warning("Odds matrix is not used when continuous probabilities are specified", 
             call. = FALSE)
   }
-  if (cont == FALSE & !is.null(type)) {
+  if (!cont && !is.null(type)) {
     warning("Type is not used when continuous probabilities are specified",
             call. = FALSE)
   }
@@ -438,15 +435,15 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     warning("Type should either have length 1 or length equal to #patterns, first
             element is used for all patterns", call. = FALSE)
   }
-  if (!is.null(odds) & !is.matrix(odds)) {
+  if (!is.null(odds) && !is.matrix(odds)) {
     odds <- matrix(odds, nrow(patterns.new), byrow = TRUE)
   }
   if (is.null(odds)) {
     odds <- ampute.default.odds(patterns = patterns.new)
   }
-  if (cont == FALSE) {
-    for (h in 1:nrow(odds)) {
-      if(any(!is.na(odds[h, ]) & odds[h, ] < 0)) {
+  if (!cont) {
+    for (h in seq_len(nrow(odds))) {
+      if(any(!is.na(odds[h, ]) && odds[h, ] < 0)) {
         stop("Odds matrix can only have positive values", call. = FALSE)
       }
     }
@@ -468,8 +465,8 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
     # Assign cases to the patterns according probs
     # Because 0 and 1 will be used for missingness, 
     # the numbering of the patterns will start from 2
-    P <- sample(x = 1:nrow(patterns.new), size = nrow(data), 
-                replace = T, prob = freq) + 1
+    P <- sample.int(x = nrow(patterns.new), size = nrow(data), 
+                replace = TRUE, prob = freq) + 1
     # Calculate missingness according MCAR or calculate weighted sum scores
     # Standardized data is used to calculate weighted sum scores
     if (mech == "MCAR") {
@@ -478,8 +475,8 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
                        prop = prop)
     } else {
       # Check if there is a pattern with merely zeroos
-      if (!is.null(check.pat[["row.zero"]]) & mech == "MAR") {
-        stop(paste("Patterns object contains merely zeroos and this kind of pattern 
+      if (!is.null(check.pat[["row.zero"]]) && mech == "MAR") {
+        stop(paste("Patterns object contains merely zeros and this kind of pattern 
                    is not possible when mechanism is MAR"), 
              call. = FALSE)
       } else {
@@ -500,7 +497,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
       }
     }
     missing.data <- data
-    for (i in 1:nrow(patterns.new)) {
+    for (i in seq_len(nrow(patterns.new))) {
       if (any(P == (i + 1))) {
         missing.data[R[[i]] == 0, patterns.new[i, ] == 0] <- NA
       }

--- a/R/RcppExports.r
+++ b/R/RcppExports.r
@@ -2,6 +2,6 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 matcher <- function(obs, mis, k) {
-    .Call('mice_matcher', PACKAGE = 'mice', obs, mis, k)
+    .Call('_mice_matcher', PACKAGE = 'mice', obs, mis, k)
 }
 

--- a/R/ampute.default.R
+++ b/R/ampute.default.R
@@ -16,10 +16,9 @@
 #'@keywords internal
 #'@export
 ampute.default.patterns <- function(n) {
-  patterns <- vapply(seq_len(n),
-                     function(i) c(rep.int(1, i - 1), 0, rep.int(1, n - i)),
-                     numeric(n)
-  return(patterns)
+  patterns.list <- lapply(seq_len(n),
+                     function(i) c(rep.int(1, i - 1), 0, rep.int(1, n - i)))
+  return(do.call(rbind, patterns.list))
 }
 
 #

--- a/R/ampute.default.R
+++ b/R/ampute.default.R
@@ -16,10 +16,9 @@
 #'@keywords internal
 #'@export
 ampute.default.patterns <- function(n) {
-  patterns <- matrix(data = NA, nrow = n, ncol = n)
-  for (i in 1:n) {
-    patterns[i, ] <- c(rep(1, i - 1), 0, rep(1, n - i))
-  }
+  patterns <- vapply(seq_len(n),
+                     function(i) c(rep.int(1, i - 1), 0, rep.int(1, n - i)),
+                     numeric(n)
   return(patterns)
 }
 
@@ -42,7 +41,7 @@ ampute.default.patterns <- function(n) {
 #'@keywords internal
 #'@export
 ampute.default.freq <- function(patterns) {
-  freq <- rep((1 / nrow(patterns)), nrow(patterns))
+  freq <- rep.int(1 / nrow(patterns), nrow(patterns))
   return(freq)
 }
 
@@ -100,7 +99,7 @@ ampute.default.weights <- function(patterns, mech) {
 #'@keywords internal
 #'@export
 ampute.default.type <- function(patterns) {
-  type <- rep("RIGHT", nrow(patterns))
+  type <- rep.int("RIGHT", nrow(patterns))
   return(type)
 }
 
@@ -123,7 +122,7 @@ ampute.default.type <- function(patterns) {
 #'@keywords internal
 #'@export
 ampute.default.odds <- function(patterns) {
-  odds <- matrix(c(1, 2, 3, 4), nrow = nrow(patterns), ncol = 4, byrow = TRUE)
+  odds <- matrix(seq_len(4), nrow = nrow(patterns), ncol = 4, byrow = TRUE)
   return(odds)
 }
 

--- a/R/ampute.discrete.R
+++ b/R/ampute.discrete.R
@@ -36,16 +36,16 @@ ampute.discrete <- function(P, scores, prop, odds) {
   # (Brand, 1999, pp. 110-113) will be induced on the weighted sum scores calculated 
   # earlier in the multivariate amputation function ampute().
   #
-  R <- list()
-  for (i in 1:nrow(odds)) {
+  R <- vector(mode = "list", length = nrow(odds))
+  for (i in seq_len(nrow(odds))) {
     if (scores[[i]][[1]] == 0) {
       R[[i]] <- 0
     } else {
       # The scores are divided into quantiles
       # Specify #quantiles by #odds values
       ng <- length(odds[i, ][!is.na(odds[i, ])])  
-      quantiles <- quantile(scores[[i]], probs = seq(0, 1, by = 1 / ng))
-      if (any(duplicated(quantiles)) | any(is.na(quantiles))) {
+      quantiles <- quantile(scores[[i]], probs = seq.int(0, 1, by = 1 / ng))
+      if (anyDuplicated(quantiles) || anyNA(quantiles)) {
         stop("Division of sum scores into quantiles did not succeed. Possibly
              the sum scores contain too few different observations (in case of
              categorical or dummy variables). Try using more variables to 
@@ -53,8 +53,8 @@ ampute.discrete <- function(P, scores, prop, odds) {
              odds matrix", call. = FALSE)
       }
       # For each candidate the quantile number is specified 
-      R.temp <- rep(NA, length(scores[[i]]))
-      for (k in 1:ng) {
+      R.temp <- rep.int(NA, length(scores[[i]]))
+      for (k in seq_len(ng)) {
         R.temp <- replace(R.temp, scores[[i]] >= quantiles[k] 
                           & scores[[i]] <= quantiles[k + 1], k)
       }
@@ -63,7 +63,7 @@ ampute.discrete <- function(P, scores, prop, odds) {
       # will receive missing data indicator 0, meaning he will be made missing 
       # according the pattern; if random value > prob, the candidate will receive
       # missing data indicator 1, meaning the candidate will remain complete. 
-      for (l in 1:ng) {
+      for (l in seq_len(ng)) {
         prob <- (ng * prop * odds[i, l]) / sum(odds[i, ], na.rm = TRUE)
         if (prob >= 1.0) {
           warning("Combination of odds matrix and desired proportion of 
@@ -75,7 +75,7 @@ ampute.discrete <- function(P, scores, prop, odds) {
         if (gn != 0) {
           random <- runif(n = gn, min = 0, max = 1)
           Q <- c()
-          for (m in 1:gn) {
+          for (m in seq_len(gn)) {
             if (random[m] <= prob) {
               Q[m] <- 0  # Candidate will be made missing
             } else {

--- a/R/ampute.mcar.R
+++ b/R/ampute.mcar.R
@@ -41,7 +41,7 @@ ampute.mcar <- function(P, patterns, prop) {
       # indicator 0, meaning he will be made missing or missing data indicator 1, 
       # meaning the candidate will remain complete.
       R.temp <- replace(P, P == (i + 1), R.temp)
-      R.temp <- replace(R[[i]], P != (i + 1), 1)
+      R.temp <- replace(R.temp, P != (i + 1), 1)
       return(R.temp)
     }
   }

--- a/R/ampute.mcar.R
+++ b/R/ampute.mcar.R
@@ -28,11 +28,10 @@ ampute.mcar <- function(P, patterns, prop) {
   # This function creates a missing data indicator for each pattern, based on 
   # a MCAR missingness mechanism. The function is used in the multivariate 
   # amputation function ampute().
-  R <- list()
-  for (i in 1:nrow(patterns)) {
+  f <- function(i) {
     # If there are no candidates in a certain pattern, the list will receive a 0
     if (length(P[P == (i + 1)]) == 0) {
-      R[[i]] <- 0
+      return(0)
     } else {
       # Otherwise, for all candidates in the pattern, the total proportion of 
       # missingness is used to define the probabilities to be missing. 
@@ -41,9 +40,12 @@ ampute.mcar <- function(P, patterns, prop) {
       # Based on the probabilities, each candidate will receive a missing data 
       # indicator 0, meaning he will be made missing or missing data indicator 1, 
       # meaning the candidate will remain complete.
-      R[[i]] <- replace(P, P == (i + 1), R.temp)
-      R[[i]] <- replace(R[[i]], P != (i + 1), 1)
+      R.temp <- replace(P, P == (i + 1), R.temp)
+      R.temp <- replace(R[[i]], P != (i + 1), 1)
+      return(R.temp)
     }
   }
+  
+  R <- lapply(seq_len(nrow(patterns)), f)
   return(R)
 }

--- a/R/as.r
+++ b/R/as.r
@@ -74,12 +74,10 @@ as.mids <- function(data, .imp = NA, .id = NA) {
   
   # no missings allowed in .imp
   imps <- data[, imp_pos]
-  if (any(is.na(imps))) stop("Values `NA` in column `.imp` are not permitted.")
+  if (anyNA(imps)) stop("Values `NA` in column `.imp` are not permitted.")
   
   # determine m
-  m <- ifelse(is.factor(imps), 
-              max(as.numeric(levels(imps))[imps]),
-              max(imps))
+  m <- if (is.factor(imps)) max(as.numeric(levels(imps))[imps]) else max(imps)
   
   # get original data part  
   vars_to_remove <- na.omit(c(imp_pos, id_pos))
@@ -95,10 +93,10 @@ as.mids <- function(data, .imp = NA, .id = NA) {
   
   # copy imputations from data into proper ini$imp elements
   names  <- names(ini$imp)
-  for (i in 1:length(names)) {
+  for (i in seq_along(names)) {
     varname <- names[i]
     if(!is.null(ini$imp[[varname]])) {
-      for(j in 1:m) {
+      for(j in seq_len(m)) {
         idx <- imps == j & is.na(data[imps == 0, varname])
         ini$imp[[varname]][j] <- data[idx, varname]
       }

--- a/R/auxiliary.r
+++ b/R/auxiliary.r
@@ -44,7 +44,7 @@ appendbreak <- function(data, brk, warp.model = warp.model, id=NULL, typ="pred")
   app$first <- FALSE
   app$typ <- typ
   app$occ <- NA
-  app <- app[rep(1:nap,length(brk)),]
+  app <- app[rep.int(seq_len(nap),length(brk)),]
   
   ## update age variables
   app$age <- rep(brk,each=nap)
@@ -54,7 +54,7 @@ appendbreak <- function(data, brk, warp.model = warp.model, id=NULL, typ="pred")
           Boundary.knots = c(brk[1],brk[k]+0.0001),
           degree = 1)
   X <- X[,-(k+1)]
-  app[,paste("x",1:ncol(X),sep="")] <- X
+  app[,paste0("x",seq_len(ncol(X)))] <- X
   
   ## update outcome variable (set to missing)
   app[,c("hgt.z","wgt.z","bmi.z")] <- NA
@@ -78,8 +78,8 @@ extractBS <- function(fit) {
 
 ## used by mice.impute.midastouch
 bootfunc.plain <- function(n){
-  random <- sample(n,replace = TRUE)
-  weights <- as.numeric(table(factor(random,levels = c(1:n))))
+  random <- sample.int(n,replace = TRUE)
+  weights <- as.numeric(table(factor(random,levels = seq_len(n))))
   return(weights)
 }
 

--- a/R/bwplot.mads.R
+++ b/R/bwplot.mads.R
@@ -49,7 +49,7 @@ bwplot.mads <- function(x, data, which.pat = NULL, standardized = TRUE,
   }
   if (is.null(which.pat)) {
     pat <- nrow(x$patterns)
-    which.pat <- c(1:pat)
+    which.pat <- seq_len(pat)
   } else {
     pat <- length(which.pat)
   }
@@ -68,7 +68,7 @@ bwplot.mads <- function(x, data, which.pat = NULL, standardized = TRUE,
       layout <- c(length(varlist), 1)
     }
   }
-  for (i in 1:pat){
+  for (i in seq_len(pat)){
     can <- which(x$cand == which.pat[i])
     mis <- matrix(NA, nrow = length(can), ncol = 2)
     nc <- which(x$patterns[which.pat[i], ] == 0)

--- a/R/bwplot.mads.R
+++ b/R/bwplot.mads.R
@@ -53,8 +53,7 @@ bwplot.mads <- function(x, data, which.pat = NULL, standardized = TRUE,
   } else {
     pat <- length(which.pat)
   }
-  formula <- as.formula(paste(paste(varlist, collapse = "+", sep = ""), 
-                              "~ factor(.amp)", sep = ""))
+  formula <- as.formula(paste0(paste0(varlist, collapse = "+"), "~ factor(.amp)"))
   data <- NULL
   if (standardized) {
     dat <- data.frame(scale(x$data))
@@ -79,46 +78,45 @@ bwplot.mads <- function(x, data, which.pat = NULL, standardized = TRUE,
       mis[is.na(x$amp[can, nc]), 1] <- "Amp"
       mis[is.na(mis[, 1]), 1] <- "Non-Amp"
     }
-    mis[, 2] <- rep(which.pat[i], length(can))
+    mis[, 2] <- rep.int(which.pat[i], length(can))
     data <- rbind(data, cbind(mis, dat[can, ]))
   }
   colnames(data) <- c(".amp", ".pat", varlist)
   p <- list()
   vec1 <- c()
   vec3 <- c()
-  for (i in 1:length(which.pat)) {
-    vec1[((i*2)-1):(i*2)] <- rep(paste(which.pat[i]), 2)
+  for (i in seq_along(which.pat)) {
+    vec1[((i*2)-1):(i*2)] <- rep.int(paste(which.pat[i]), 2)
   }
-  for (j in 1:length(varlist)) {
-    vec3[j] <- paste("", varlist[j])
-  }
+
+  vec3 <- paste("", varlist)
   var <- length(varlist)
   if (descriptives) {
     desc <- array(NA, dim = c(2 * length(which.pat), 4, var),
                   dimnames = list(Pattern = vec1, 
                                   Descriptives = c("Amp", "Mean", "Var", "N"), 
                                   Variable = vec3))
-    desc[, 1, ] <- rep(rep(c(1, 0), length(which.pat)), var)
-    for (i in 1:length(which.pat)) {
+    desc[, 1, ] <- rep.int(rep.int(c(1, 0), length(which.pat)), var)
+    for (i in seq_along(which.pat)) {
       wp <- which.pat[i]
       desc[(i*2) - 1, 2, ] <- 
-        round(sapply(varlist, function(x)
-          mean(data[data$.pat == wp & data$.amp == "Amp", x])), 5)
+        round(vapply(varlist, function(x)
+          mean(data[data$.pat == wp & data$.amp == "Amp", x]), numeric(1)), 5)
       desc[(i*2), 2, ] <- 
-        round(sapply(varlist, function(x)
-          mean(data[data$.pat == wp & data$.amp == "Non-Amp", x])), 5)
+        round(vapply(varlist, function(x)
+          mean(data[data$.pat == wp & data$.amp == "Non-Amp", x]), numeric(1)), 5)
       desc[(i*2) - 1, 3, ] <- 
-        round(sapply(varlist, function(x)
-          var(data[data$.pat == wp & data$.amp == "Amp", x])), 5)
+        round(vapply(varlist, function(x)
+          var(data[data$.pat == wp & data$.amp == "Amp", x]), numeric(1)), 5)
       desc[(i*2), 3, ] <- 
-        round(sapply(varlist, function(x)
-          var(data[data$.pat == wp & data$.amp == "Non-Amp", x])), 5)
+        round(vapply(varlist, function(x)
+          var(data[data$.pat == wp & data$.amp == "Non-Amp", x]), numeric(1)), 5)
       desc[(i*2) - 1, 4, ] <- 
-        sapply(varlist, function(x)
-          length(data[data$.pat == wp & data$.amp == "Amp", x]))
+        vapply(varlist, function(x)
+          length(data[data$.pat == wp & data$.amp == "Amp", x]), numeric(1))
       desc[(i*2), 4, ] <- 
-        sapply(varlist, function(x)
-          length(data[data$.pat == wp & data$.amp == "Non-Amp", x]))
+        vapply(varlist, function(x)
+          length(data[data$.pat == wp & data$.amp == "Non-Amp", x]), numeric(1))
     }
     p[["Descriptives"]] <- desc
   }
@@ -133,7 +131,7 @@ bwplot.mads <- function(x, data, which.pat = NULL, standardized = TRUE,
                 plot.line = list(col = "black"), 
                 strip.background = list(col = "grey95"))
 
-  for (i in 1:pat) {
+  for (i in seq_len(pat)) {
     p[[paste("Boxplot pattern", which.pat[i])]] <- 
       bwplot(x = formula, data = data[data$.pat == which.pat[i], ],
              multiple = TRUE, outer = TRUE, layout = layout, 

--- a/R/bwplot.r
+++ b/R/bwplot.r
@@ -187,8 +187,8 @@ bwplot.mids <- function(x,
                  as.table = as.table)
     
     ## create formula if not given (in call$data !)
-    vnames <- names(cd)[-(1:2)]
-    allfactors <- unlist(lapply(cd,is.factor))[-(1:2)]
+    vnames <- names(cd)[-seq_len(2)]
+    allfactors <- unlist(lapply(cd,is.factor))[-seq_len(2)]
     if (missing(data)) {
         vnames <- vnames[!allfactors]
         formula <- as.formula(paste(paste(vnames,collapse="+",sep=""),"~.imp",sep=""))
@@ -218,13 +218,13 @@ bwplot.mids <- function(x,
     if (!is.null(call$groups) & nona) gp <- call$groups
     else {
         if (nona) {
-            for (i in 1:length(ynames)) {
+            for (i in seq_along(ynames)) {
                 yvar <- ynames[i]
                 select <- cd$.imp!=0 & !r[,yvar]
                 cd[select, yvar] <- NA
             }
         } else {
-            for (i in 1:length(ynames)) {
+            for (i in seq_along(ynames)) {
                 yvar <- ynames[i]
                 select <- cd$.imp!=0 & !nagp
                 cd[select, yvar] <- NA
@@ -243,7 +243,7 @@ bwplot.mids <- function(x,
     }
     
     ## change axis defaults of extended formula interface
-    if (is.null(call$xlab) & !is.na(match(".imp",xnames))) {
+    if (is.null(call$xlab) && !is.na(match(".imp",xnames))) {
         dots$xlab <- ""
         if (length(xnames)==1) dots$xlab <- "Imputation number"
     }

--- a/R/cbind.r
+++ b/R/cbind.r
@@ -82,9 +82,9 @@ cbind.mids <- function(x, y = NULL, ...) {
   if (!is.mids(y)) {
     # Combine y and dots into data.frame
     if (is.null(y)) {
-      y <- cbind(...) 
+      y <- cbind.data.frame(...) 
     } else {
-      y <- cbind(y, ...)
+      y <- cbind.data.frame(y, ...)
     }
     if (is.matrix(y) || is.vector(y) || is.factor(y))
       y <- as.data.frame(y)
@@ -123,7 +123,7 @@ cbind.mids <- function(x, y = NULL, ...) {
       m <- matrix(NA,
                   nrow = sum(!r[, j]),
                   ncol = x$m,
-                  dimnames = list(row.names(y)[r[, j] == FALSE], seq_len(m)))
+                  dimnames = list(row.names(y)[!r[, j]], seq_len(m)))
       as.data.frame(m)
     }
       

--- a/R/cbind.r
+++ b/R/cbind.r
@@ -82,16 +82,16 @@ cbind.mids <- function(x, y = NULL, ...) {
   if (!is.mids(y)) {
     # Combine y and dots into data.frame
     if (is.null(y)) {
-      y <- cbind.data.frame(...) 
+      y <- cbind(...) 
     } else {
-      y <- cbind.data.frame(y, ...)
+      y <- cbind(y, ...)
     }
-    if (is.matrix(y) | is.vector(y) | is.factor(y))
+    if (is.matrix(y) || is.vector(y) || is.factor(y))
       y <- as.data.frame(y)
     
     # Replicate rows of y
     if (nrow(y) == 1) {
-      y <- y[rep(row.names(y), nrow(x$data)), 1:length(y)]
+      y <- y[rep(row.names(y), nrow(x$data)), seq_along(y)]
       row.names(y) <- row.names(x$data)
     }
     
@@ -118,16 +118,21 @@ cbind.mids <- function(x, y = NULL, ...) {
     # The original data of y will be copied into the multiple imputed dataset, 
     # including the missing values of y.
     r <- (!is.na(y))
-    imp <- vector("list", ncol(y))
-    for (j in 1:ncol(y)) {
-      imp[[j]] <- as.data.frame(matrix(NA, nrow = sum(!r[, j]), ncol = x$m))
-      dimnames(imp[[j]]) <- list(row.names(y)[r[, j] == FALSE], 1:m)
+    
+    f <- function(j) {
+      m <- matrix(NA,
+                  nrow = sum(!r[, j]),
+                  ncol = x$m,
+                  dimnames = list(row.names(y)[r[, j] == FALSE], seq_len(m)))
+      as.data.frame(m)
     }
+      
+    imp <- lapply(seq_len(ncol(y)), f)
     imp <- c(x$imp, imp)
     names(imp) <- varnames
     
     # The imputation method for (columns in) y will be set to ''.
-    method <- c(x$method, rep("", ncol(y)))
+    method <- c(x$method, rep.int("", ncol(y)))
     names(method) <- c(names(x$method), colnames(y))
     
     # The variable(s) in y are included in the predictorMatrix.  y is not used as predictor as well as not imputed.
@@ -139,7 +144,7 @@ cbind.mids <- function(x, y = NULL, ...) {
     visitSequence <- x$visitSequence
     
     # The post vector for (columns in) y will be set to ''.
-    post <- c(x$post, rep("", ncol(y)))
+    post <- c(x$post, rep.int("", ncol(y)))
     names(post) <- c(names(x$post), colnames(y))
     
     # seed, lastSeedvalue, number of iterations, chainMean and chainVar is taken as in mids object x.
@@ -235,12 +240,12 @@ cbind.mids <- function(x, y = NULL, ...) {
                                          dimnames(y$chainMean)[[1]]), 
                                        dimnames(x$chainMean)[[2]], 
                                        dimnames(x$chainMean)[[3]]))
-    chainMean[1:dim(x$chainMean)[1], , ] <- x$chainMean
+    chainMean[seq_len(dim(x$chainMean)[1]), , ] <- x$chainMean
     
     if (iteration <= dim(y$chainMean)[2]) {
-      chainMean[(dim(x$chainMean)[1] + 1):dim(chainMean)[1], , ] <- y$chainMean[, 1:iteration, ] 
+      chainMean[(dim(x$chainMean)[1] + 1):dim(chainMean)[1], , ] <- y$chainMean[, seq_len(iteration), ] 
     } else { 
-      chainMean[(dim(x$chainMean)[1] + 1):dim(chainMean)[1], 1:dim(y$chainMean)[2], ] <- y$chainMean
+      chainMean[(dim(x$chainMean)[1] + 1):dim(chainMean)[1], seq_len(dim(y$chainMean)[2]), ] <- y$chainMean
     }
     
     chainVar <- array(data = NA, dim = c(dim(x$chainVar)[1] + dim(y$chainVar)[1], iteration, m), 
@@ -248,12 +253,12 @@ cbind.mids <- function(x, y = NULL, ...) {
                                         dimnames(y$chainVar)[[1]]), 
                                       dimnames(x$chainVar)[[2]], 
                                       dimnames(x$chainVar)[[3]]))
-    chainVar[1:dim(x$chainVar)[1], , ] <- x$chainVar
+    chainVar[seq_len(dim(x$chainVar)[1]), , ] <- x$chainVar
     
     if (iteration <= dim(y$chainVar)[2]) {
-      chainVar[(dim(x$chainVar)[1] + 1):dim(chainVar)[1], , ] <- y$chainVar[, 1:iteration, ] 
+      chainVar[(dim(x$chainVar)[1] + 1):dim(chainVar)[1], , ] <- y$chainVar[, seq_len(iteration), ] 
     } else { 
-      chainVar[(dim(x$chainVar)[1] + 1):dim(chainVar)[1], 1:dim(y$chainVar)[2], ] <- y$chainVar
+      chainVar[(dim(x$chainVar)[1] + 1):dim(chainVar)[1], seq_len(dim(y$chainVar)[2]), ] <- y$chainVar
     }
     
     loggedEvents <- x$loggedEvents

--- a/R/complete.r
+++ b/R/complete.r
@@ -84,7 +84,7 @@ complete <- function(x, action = 1, include = FALSE) {
     where <- x$where
     if (is.null(where))
       where <- is.na(data)
-    ind <- (1:ncol(data))[colSums(where) > 0]
+    ind <- seq_len(ncol(data))[colSums(where) > 0]
     for (j in ind) {
       if (is.null(x$imp[[j]]))
         data[where[, j], j] <- NA
@@ -97,28 +97,28 @@ complete <- function(x, action = 1, include = FALSE) {
     m <- x$m
     nr <- nrow(x$data)
     nc <- ncol(x$data)
-    add <- ifelse(include, 1, 0)
+    add <- as.numeric(include)
     mylist <- vector("list", length = m + add)
     # recursive call
-    for (j in 1:length(mylist)) mylist[[j]] <- Recall(x, j - add)
+    for (j in seq_along(mylist)) mylist[[j]] <- Recall(x, j - add)
     if (code == 1) {
       # long
       data <- do.call(rbind, mylist)
       data <- data.frame(.imp = as.factor(rep((1 - add):m, each = nr)), 
-                         .id = rep(row.names(x$data), m + add), 
+                         .id = rep.int(row.names(x$data), m + add), 
                          data)
-      row.names(data) <- 1:nrow(data)
+      row.names(data) <- seq_len(nrow(data))
     }
     if (code >= 2 && code <= 3) {
       # broad or repeated
       data <- do.call(cbind, mylist)
-      names(data) <- paste(rep(names(x$data), m), 
-                           rep((1 - add):m, rep(nc, m + add)), 
+      names(data) <- paste(rep.int(names(x$data), m), 
+                           rep.int((1 - add):m, rep.int(nc, m + add)), 
                            sep = ".")
     }
     if (code == 3) {
       # repeated
-      data <- data[, order(rep(1:nc, m + add))]
+      data <- data[, order(rep.int(seq_len(nc), m + add))]
     }
     return(data)
   }

--- a/R/densityplot.r
+++ b/R/densityplot.r
@@ -201,8 +201,8 @@ densityplot.mids <- function(x,
                plot.points = plot.points)
 
   ## create formula if not given (in call$data !)
-  vnames <- names(cd)[-(1:2)]
-  allfactors <- unlist(lapply(cd,is.factor))[-(1:2)]
+  vnames <- names(cd)[-seq_len(2)]
+  allfactors <- vapply(cd, is.factor, logical(1))[-seq_len(2)]
   if (missing(data)) {
     vnames <- vnames[!allfactors & x$nmis>2 & x$nmis < nrow(x$data)-1]
     formula <- as.formula(paste("~",paste(vnames,collapse="+",sep=""),sep=""))
@@ -217,7 +217,7 @@ densityplot.mids <- function(x,
 
   ## calculate selection vector gp
   nona <- is.null(call$na.groups)
-  if (!is.null(call$groups) & nona) gp <- call$groups
+  if (!is.null(call$groups) && nona) gp <- call$groups
   else {
     if (nona) {
       ## na.df <- r[, xnames, drop=FALSE]
@@ -226,28 +226,28 @@ densityplot.mids <- function(x,
       ## gp <- unlist(lapply(na.df, rep, x$m+1))
       ## gp[imp0] <- !gp[imp0]
       ## call$subset <- ss & gp
-      for (i in 1:length(xnames)) {
+      for (i in seq_along(xnames)) {
         xvar <- xnames[i]
         select <- cd$.imp!=0 & !r[,xvar]
         cd[select, xvar] <- NA
       }
-      gp <- rep(cd$.imp, length(xnames))
+      gp <- rep.int(cd$.imp, length(xnames))
     } else {
-      for (i in 1:length(xnames)) {
+      for (i in seq_along(xnames)) {
         xvar <- xnames[i]
         select <- cd$.imp!=0 & !nagp
         cd[select, xvar] <- NA
       }
-      gp <- rep(cd$.imp, length(xnames))
+      gp <- rep.int(cd$.imp, length(xnames))
     }
   }
 
   ## replicate color 2 if group=.imp is part of xnames
-  mustreplicate <- !(!is.null(call$groups) & nona) & mayreplicate
+  mustreplicate <- !(!is.null(call$groups) && nona) && mayreplicate
   if (mustreplicate) {
-    theme$superpose.line$col <- rep(theme$superpose.line$col[1:2], c(1,x$m))
+    theme$superpose.line$col <- rep(theme$superpose.line$col[seq_len(2)], c(1,x$m))
     theme$superpose.line$lwd <- rep(c(theme$superpose.line$lwd[1]*thicker, theme$superpose.line$lwd[1]),c(1,x$m))
-    theme$superpose.symbol$col <- rep(theme$superpose.symbol$col[1:2], c(1,x$m))
+    theme$superpose.symbol$col <- rep(theme$superpose.symbol$col[seq_len(2)], c(1,x$m))
     theme$superpose.symbol$pch <- c(NA,49:(49+x$m-1))
   }
 

--- a/R/df.residual.r
+++ b/R/df.residual.r
@@ -19,9 +19,9 @@ df.residual.default <- function(object, q = 1.3, ...) {
     
     mk <- try(c <- coef(object), silent = TRUE)
     mn <- try(f <- fitted(object), silent = TRUE)
-    if (inherits(mk, "try-error") | inherits(mn, "try-error")) 
+    if (inherits(mk, "try-error") || inherits(mn, "try-error")) 
         return(NULL)
-    n <- ifelse(is.data.frame(f) | is.matrix(f), nrow(f), length(f))
+    n <- if (is.data.frame(f) || is.matrix(f)) nrow(f) else length(f)
     k <- length(c)
     if (k == 0 | n == 0) 
         return(NULL)

--- a/R/flux.r
+++ b/R/flux.r
@@ -175,5 +175,5 @@ f <- flux(data, local)
 #'@export
 fico <- function(data){
   ic <- ici(data)
-  unlist(lapply(data, FUN <- function(x) sum((!is.na(x)) & ic)/sum(!is.na(x))))
+  unlist(lapply(data, FUN = function(x) sum((!is.na(x)) & ic)/sum(!is.na(x))))
 }

--- a/R/ibind.r
+++ b/R/ibind.r
@@ -32,7 +32,7 @@ ibind <- function(x, y) {
   call <- match.call()
   call <- c(x$call, call)
   
-  if (!is.mids(y) & !is.mids(x)) 
+  if (!is.mids(y) && !is.mids(x)) 
     stop("Arguments `x` and `y` not of class `mids`")
   if (!identical(is.na(x$data), is.na(y$data)))
     stop("Differences detected in the missing data pattern")
@@ -52,24 +52,20 @@ ibind <- function(x, y) {
     stop("Differences detected between `x$pad$categories` and `y$pad$categories`")
   
   visitSequence <- x$visitSequence
-  imp <- vector("list", ncol(x$data))
-  for (j in visitSequence) {
-    imp[[j]] <- cbind(x$imp[[j]], y$imp[[j]])
-  }
-  
+  imp <- lapply(visitSequence, function(j) cbind(x$imp[[j]], y$imp[[j]]))
   m <- (x$m + y$m)
   iteration <- max(x$iteration, y$iteration)
   
   chainMean <- chainVar <- array(NA, dim = c(length(visitSequence), iteration, m), 
                                  dimnames = list(names(visitSequence), 
-                                                 1:iteration, paste("Chain", 1:m)))
-  for (j in 1:x$m) {
-    chainMean[, 1:x$iteration, j] <- x$chainMean[, , j]
-    chainVar[, 1:x$iteration, j] <- x$chainVar[, , j]
+                                                 seq_len(iteration), paste("Chain", seq_len(m))))
+  for (j in seq_len(x$m)) {
+    chainMean[, seq_len(x$iteration), j] <- x$chainMean[, , j]
+    chainVar[, seq_len(x$iteration), j] <- x$chainVar[, , j]
   }
-  for (j in 1:y$m) {
-    chainMean[, 1:y$iteration, j + x$m] <- y$chainMean[, , j]
-    chainVar[, 1:y$iteration, j + x$m] <- y$chainVar[, , j]
+  for (j in seq_len(y$m)) {
+    chainMean[, seq_len(y$iteration), j + x$m] <- y$chainMean[, , j]
+    chainVar[, seq_len(y$iteration), j + x$m] <- y$chainVar[, , j]
   }
   
   z <- list(call = call, data = x$data, where = x$where, 

--- a/R/ibind.r
+++ b/R/ibind.r
@@ -52,7 +52,11 @@ ibind <- function(x, y) {
     stop("Differences detected between `x$pad$categories` and `y$pad$categories`")
   
   visitSequence <- x$visitSequence
-  imp <- lapply(visitSequence, function(j) cbind(x$imp[[j]], y$imp[[j]]))
+  imp <- vector("list", ncol(x$data))
+  for (j in visitSequence) {
+    imp[[j]] <- cbind(x$imp[[j]], y$imp[[j]])
+  }
+  
   m <- (x$m + y$m)
   iteration <- max(x$iteration, y$iteration)
   

--- a/R/internal.r
+++ b/R/internal.r
@@ -71,7 +71,7 @@ updateLog <- function(out = NULL, meth = NULL, frame = 2) {
   s <- get("state", parent.frame(frame))
   r <- get("loggedEvents", parent.frame(frame))
   
-  rec <- data.frame(it = s$it, im = s$im, co = s$co, dep = s$dep, meth = ifelse(is.null(meth), s$meth, meth), out = if (is.null(out)) "" else out)
+  rec <- data.frame(it = s$it, im = s$im, co = s$co, dep = s$dep, meth = if(is.null(meth)) s$meth else meth, out = if (is.null(out)) "" else out)
   
   if (s$log)
     rec <- rbind(r, rec)

--- a/R/internal.r
+++ b/R/internal.r
@@ -18,16 +18,16 @@ remove.lindep <- function(x, y, ry, eps = 1e-04, maxcor = 0.99, allow.na = FALSE
     stop("\n Argument 'eps' must be positive.")
   
   # Keep all predictors if we allow imputation of fully missing variable
-  if (allow.na & sum(ry) == 0) {
+  if (allow.na && sum(ry) == 0) {
     updateLog(out = "No observed outcomes, keep all predictors", frame = 3)
-    return(rep(TRUE, ncol(x)))
+    return(rep.int(TRUE, ncol(x)))
   }
   
   xobs <- x[ry, , drop = FALSE]
   yobs <- as.numeric(y[ry])
   keep <- unlist(apply(xobs, 2, var) > eps)
   keep[is.na(keep)] <- FALSE
-  highcor <- suppressWarnings((unlist(apply(xobs, 2, cor, yobs)) < maxcor))
+  highcor <- suppressWarnings(unlist(apply(xobs, 2, cor, yobs) < maxcor))
   keep <- keep & highcor
   if (all(!keep))
     updateLog(out = "All predictors are constant or have too high correlation.", frame = 3)
@@ -37,7 +37,7 @@ remove.lindep <- function(x, y, ry, eps = 1e-04, maxcor = 0.99, allow.na = FALSE
   eig <- eigen(cx, symmetric = TRUE)
   ncx <- cx
   while (eig$values[k]/eig$values[1] < eps) {
-    j <- (1:k)[order(abs(eig$vectors[, k]), decreasing = TRUE)[1]]
+    j <- seq_len(k)[order(abs(eig$vectors[, k]), decreasing = TRUE)[1]]
     keep[keep][j] <- FALSE
     ncx <- cx[keep[keep], keep[keep], drop = FALSE]
     k <- k - 1
@@ -61,7 +61,7 @@ find.collinear <- function(x, threshold = 0.999, ...) {
   xo <- x[, ord, drop = FALSE]  ## SvB 24mar2011
   varnames <- dimnames(xo)[[2]]
   z <- suppressWarnings(cor(xo, use = "pairwise.complete.obs"))
-  hit <- outer(1:nvar, 1:nvar, "<") & (abs(z) >= threshold)
+  hit <- outer(seq_len(nvar), seq_len(nvar), "<") & (abs(z) >= threshold)
   out <- apply(hit, 2, any, na.rm = TRUE)
   return(varnames[out])
 }
@@ -71,8 +71,7 @@ updateLog <- function(out = NULL, meth = NULL, frame = 2) {
   s <- get("state", parent.frame(frame))
   r <- get("loggedEvents", parent.frame(frame))
   
-  rec <- data.frame(it = s$it, im = s$im, co = s$co, dep = s$dep, meth = ifelse(is.null(meth), s$meth, meth), out = ifelse(is.null(out),
-                                                                                                                           "", out))
+  rec <- data.frame(it = s$it, im = s$im, co = s$co, dep = s$dep, meth = ifelse(is.null(meth), s$meth, meth), out = if (is.null(out)) "" else out)
   
   if (s$log)
     rec <- rbind(r, rec)

--- a/R/lm.r
+++ b/R/lm.r
@@ -34,12 +34,7 @@ lm.mids <- function(formula, data, ...) {
     call <- match.call()
     if (!is.mids(data)) 
         stop("The data must have class mids")
-    analyses <- as.list(1:data$m)  #
-    # do the repated analysis, store the result
-    for (i in 1:data$m) {
-        data.i <- complete(data, i)
-        analyses[[i]] <- lm(formula, data = data.i, ...)
-    }
+    analyses <- lapply(seq_len(data$m), function(i) lm(formula, data = complete(data, i), ...))
     # return the complete data analyses as a list of length nimp
     object <- list(call = call, call1 = data$call, nmis = data$nmis, analyses = analyses)
     oldClass(object) <- c("mira", "lm")  ## FEH
@@ -89,12 +84,8 @@ glm.mids <- function(formula, family = gaussian, data, ...) {
     call <- match.call()
     if (!is.mids(data)) 
         stop("The data must have class mids")
-    analyses <- as.list(1:data$m)  #
-    # do the repated analysis, store the result
-    for (i in 1:data$m) {
-        data.i <- complete(data, i)
-        analyses[[i]] <- glm(formula, family = family, data = data.i, ...)  ## SvB 22jan13
-    }
+    analyses <- lapply(seq_len(data$m),
+                       function(i) glm(formula, family = family, data = complete(data, i), ...))
     # return the complete data analyses as a list of length nimp
     object <- list(call = call, call1 = data$call, nmis = data$nmis, analyses = analyses)
     oldClass(object) <- c("mira", "glm", "lm")  ## FEH

--- a/R/md.pairs.r
+++ b/R/md.pairs.r
@@ -41,7 +41,7 @@ md.pairs <- function(data) {
     # rm:  response-missing pairs
     # mr:  missing-response pairs
     # mm:  missing-missing pairs
-    if (!(is.matrix(data) | is.data.frame(data))) 
+    if (!(is.matrix(data) || is.data.frame(data))) 
         stop("Data should be a matrix or dataframe")
     if (ncol(data) < 2) 
         stop("Data should have at least two columns")

--- a/R/md.pattern.r
+++ b/R/md.pattern.r
@@ -48,7 +48,7 @@ md.pattern <- function(x) {
     # SvB, 13-7-99
     # SvB, 32 columns bug removed - 8mar2012
     #
-    if (!(is.matrix(x) | is.data.frame(x))) 
+    if (!(is.matrix(x) || is.data.frame(x))) 
         stop("Data should be a matrix or dataframe")
     if (ncol(x) < 2) 
         stop("Data should have at least two columns")
@@ -61,7 +61,7 @@ md.pattern <- function(x) {
     r <- 1 * is.na(x)
     nmis <- as.integer(apply(r, 2, sum))
     names(nmis) <- dimnames(x)[[2]]  # index the missing data patterns
-    mdp <- (r %*% (2^((1:ncol(x)) - 1))) + 1  # do row sort  SvB 8mar2012
+    mdp <- (r %*% (2^((seq_len(ncol(x))) - 1))) + 1  # do row sort  SvB 8mar2012
     ro <- order(mdp)
     x <- matrix(x[ro, ], n, p)  ##pm 04/02
     mdp <- mdp[ro]

--- a/R/mdc.r
+++ b/R/mdc.r
@@ -65,7 +65,7 @@ mdc <- function(r = "observed", s = "symbol",
             cli <- hcl(0, 100, 40)
             clc <- "black"
         }
-    } else if (transparent == FALSE) {
+    } else if (!transparent) {
         cso <- hcl(240, 100, 40)
         csi <- hcl(0, 100, 40)
         csc <- "black"

--- a/R/mice.impute.2l.lmer.R
+++ b/R/mice.impute.2l.lmer.R
@@ -50,7 +50,7 @@ mice.impute.2l.lmer <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
   if (intercept) {
     x <- cbind(1, as.matrix(x))
     type <- c(2, type)
-    dimnames(x)[[2]] <- paste0("v", 1:ncol(x))
+    dimnames(x)[[2]] <- paste0("v", seq_len(ncol(x)))
   }
   
   # define cluster, random and fixed effects
@@ -59,7 +59,7 @@ mice.impute.2l.lmer <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
   fixe <- names(x)[type > 0]
   
   n.class <- length(unique(x[, clust]))
-  x[, clust] <- factor(x[, clust], labels = 1:n.class)
+  x[, clust] <- factor(x[, clust], labels = seq_len(n.class))
   lev <- levels(x[, clust])
   
   X <- x[, fixe, drop = FALSE]
@@ -161,7 +161,7 @@ mice.impute.2l.lmer <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
         bi.star <- myi + A %*% rnorm(length(myi))
       } else {
         bi.star <- myi
-        warning(paste0("b_", jj , " fixed to estimate"))
+        warning("b_", jj, " fixed to estimate")
       }
     }
     

--- a/R/mice.impute.2l.norm.r
+++ b/R/mice.impute.2l.norm.r
@@ -52,7 +52,7 @@ mice.impute.2l.norm <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
         Z <- matrix(0, p, p)
         diag(Z) <- sqrt(rchisq(p, df:(df - p + 1)))
         if (p > 1) {
-            pseq <- 1:(p - 1)
+            pseq <- seq_len(p - 1)
             Z[rep(p * pseq, pseq) + unlist(lapply(pseq, seq))] <- rnorm(p * (p - 1)/2)
         }
         crossprod(Z %*% SqrtSigma)
@@ -92,9 +92,9 @@ mice.impute.2l.norm <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
     ## Initialize
     n.iter <- 100
     if (is.null(wy)) wy <- !ry
-    n.class <- length(unique(x[, type == (-2)]))
+    n.class <- length(unique(x[, type == -2]))
     if (n.class == 0) stop("No class variable")
-    gf.full <- factor(x[, type == (-2)], labels = 1:n.class)
+    gf.full <- factor(x[, type == -2], labels = seq_len(n.class))
     gf <- gf.full[ry]
     XG <- split.data.frame(as.matrix(x[ry, type == 2]), gf)
     X.SS <- lapply(XG, crossprod)
@@ -104,16 +104,16 @@ mice.impute.2l.norm <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
     
     bees <- matrix(0, nrow = n.class, ncol = n.rc)
     ss <- vector(mode = "numeric", length = n.class)
-    mu <- rep(0, n.rc)
+    mu <- rep.int(0, n.rc)
     inv.psi <- diag(1, n.rc, n.rc)
-    inv.sigma2 <- rep(1, n.class)
+    inv.sigma2 <- rep.int(1, n.class)
     sigma2.0 <- 1
     theta <- 1
     
     ## Execute Gibbs sampler
-    for (iter in 1:n.iter) {
+    for (iter in seq_len(n.iter)) {
         ## Draw bees
-        for (class in 1:n.class) {
+        for (class in seq_len(n.class)) {
             vv <- symridge(inv.sigma2[class] * X.SS[[class]] + inv.psi, ...)
             bees.var <- chol2inv(chol(vv))
             bees[class, ] <- drop(bees.var %*% (crossprod(inv.sigma2[class] * XG[[class]], yg[[class]]) + inv.psi %*% mu)) + 

--- a/R/mice.impute.2l.pan.r
+++ b/R/mice.impute.2l.pan.r
@@ -132,13 +132,13 @@ mice.impute.2l.pan <- function(y, ry, x, type, intercept=TRUE, paniter = 500 ,
     }
         
     # add groupmeans in the regression model
-    if ( sum( type %in% c(3,4)) > 0 ){ 
+    if (any(type %in% c(3,4))) { 
         x0 <- as.matrix(cbind( x[ , type == -2  ]  , x[ , type %in% c(3,4) ]  ))
         colnames(x0) <- c( colnames(x)[ type==-2] , colnames(x)[ type %in% c(3,4) ] )
-        type0 <- c( -2 , rep(1 , ncol(x0)-1) )
+        type0 <- c( -2 , rep.int(1 , ncol(x0)-1) )
         x0.aggr <- as.matrix( .mice.impute.2l.groupmean(y = y , ry=ry , x = x0 , 
                                                         type = type0  , grmeanwarning=FALSE , ...)   )
-        colnames(x0.aggr) <- paste( "M." , colnames(x0)[-1] , sep="")
+        colnames(x0.aggr) <- paste0( "M." , colnames(x0)[-1])
         # groupcentering
         if ( groupcenter.slope ){ 
             x0.aggr1 <- as.matrix(x0.aggr)
@@ -149,7 +149,7 @@ mice.impute.2l.pan <- function(y, ry, x, type, intercept=TRUE, paniter = 500 ,
         # combine covariate matrix
         x <- cbind( x , x0.aggr )
         # add type
-        type1 <- c( type , rep(1 , ncol(x0.aggr) ) )
+        type1 <- c( type , rep.int(1 , ncol(x0.aggr) ) )
         names(type1) <- c( names(type) , colnames(x0.aggr) )   
         type1[ type1 == 3 ] <- 1
         type1[ type1 == 4 ] <- 2
@@ -211,7 +211,7 @@ mice.impute.2l.pan <- function(y, ry, x, type, intercept=TRUE, paniter = 500 ,
 .mice.impute.2l.groupmean <- function (y, ry, x, type , grmeanwarning=TRUE, ...){  
     if ( ( ncol(x) > 2 ) & grmeanwarning )   warning("\nMore than one variable is requested to be aggregated.\n")    
     # calculate aggregated values
-    a1 <- aggregate( x[, type %in% c(1,2) ] , list( x[,type == -2] ) , mean , na.rm=T)
+    a1 <- aggregate( x[, type %in% c(1,2) ] , list( x[,type == -2] ) , mean , na.rm=TRUE)
     i1 <- match( x[,type == -2] , a1[,1] )
     ximp <- as.matrix(a1[i1,-1])
     colnames(ximp) <- paste( names(type)[ type %in% c(1,2) ] , names(type)[ type == -2 ] , sep="." )

--- a/R/mice.impute.2lonly.mean.r
+++ b/R/mice.impute.2lonly.mean.r
@@ -33,7 +33,7 @@ mice.impute.2lonly.mean <- function(y, ry, x, type, wy = NULL, ...) {
   # deal with empty classes (will be NaN)
   empty.classes <- class[!class %in% classobs]
   classobs <- c(classobs, empty.classes)
-  yobs <- c(yobs, rep(NA, length(empty.classes)))
+  yobs <- c(yobs, rep.int(NA, length(empty.classes)))
   
   # return the means per class
   ymean <- aggregate(yobs, list(classobs), mean, na.rm = TRUE)

--- a/R/mice.impute.cart.r
+++ b/R/mice.impute.cart.r
@@ -65,7 +65,7 @@ mice.impute.cart <- function(y, ry, x, wy = NULL, minbucket = 5, cp = 1e-04,
     fit$frame$yval <- as.numeric(row.names(fit$frame))
     nodes <- predict(object = fit, newdata = xmis)
     donor <- lapply(nodes, function(s) yobs[leafnr == s])
-    impute <- sapply(1:length(donor), function(s) sample(donor[[s]], 1))
+    impute <- vapply(seq_along(donor), function(s) sample(donor[[s]], 1), numeric(1))
   } else
   {
     fit <- rpart(yobs ~ ., data = cbind(yobs, xobs), method = "class", 

--- a/R/mice.impute.logreg.r
+++ b/R/mice.impute.logreg.r
@@ -177,7 +177,7 @@ augment <- function(y, ry, x, wy, maxcat = 50) {
   e <- rep(rep(icod, each = 2), p)
   
   dimnames(d) <- list(paste0("AUG", seq_len(nrow(d))), dimnames(x)[[2]])
-  xa <- rbind(x, d)
+  xa <- rbind.data.frame(x, d)
   # beware, concatenation of factors
   ya <- if (is.factor(y)) as.factor(levels(y)[c(y, e)]) else c(y, e)
   rya <- c(ry, rep.int(TRUE, nr))

--- a/R/mice.impute.logreg.r
+++ b/R/mice.impute.logreg.r
@@ -150,7 +150,7 @@ augment <- function(y, ry, x, wy, maxcat = 50) {
   icod <- sort(unique(unclass(y)))
   k <- length(icod)
   if (k > maxcat) 
-    stop(paste("Maximum number of categories (", maxcat, ") exceeded", sep = ""))
+    stop("Maximum number of categories (", maxcat, ") exceeded")
   p <- ncol(x)
   
   # skip augmentation if there are no predictors
@@ -169,21 +169,20 @@ augment <- function(y, ry, x, wy, maxcat = 50) {
   maxx <- apply(x, 2, max, na.rm = TRUE)
   nr <- 2 * p * k
   a <- matrix(mean, nrow = nr, ncol = p, byrow = TRUE)
-  b <- matrix(rep(c(rep(c(0.5, -0.5), k), rep(0, nr)), length = nr * p), nrow = nr, ncol = p, byrow = FALSE)
+  b <- matrix(rep(c(rep.int(c(0.5, -0.5), k), rep.int(0, nr)), length = nr * p), nrow = nr, ncol = p, byrow = FALSE)
   c <- matrix(sd, nrow = nr, ncol = p, byrow = TRUE)
   d <- a + b * c
   d <- pmax(matrix(minx, nrow = nr, ncol = p, byrow = TRUE), d, na.rm = TRUE)
   d <- pmin(matrix(maxx, nrow = nr, ncol = p, byrow = TRUE), d, na.rm = TRUE)
   e <- rep(rep(icod, each = 2), p)
   
-  dimnames(d) <- list(paste("AUG", 1:nrow(d), sep = ""), dimnames(x)[[2]])
-  xa <- rbind.data.frame(x, d)
+  dimnames(d) <- list(paste0("AUG", seq_len(nrow(d))), dimnames(x)[[2]])
+  xa <- rbind(x, d)
   # beware, concatenation of factors
-  if (is.factor(y)) 
-    ya <- as.factor(levels(y)[c(y, e)]) else ya <- c(y, e)
-  rya <- c(ry, rep(TRUE, nr))
-  wya <- c(wy, rep(FALSE, nr))
-  wa <- c(rep(1, length(y)), rep((p + 1)/nr, nr))
+  ya <- if (is.factor(y)) as.factor(levels(y)[c(y, e)]) else c(y, e)
+  rya <- c(ry, rep.int(TRUE, nr))
+  wya <- c(wy, rep.int(FALSE, nr))
+  wa <- c(rep.int(1, length(y)), rep.int((p + 1)/nr, nr))
   
   return(list(y = ya, ry = rya, x = xa, w = wa, wy = wya))
 }

--- a/R/mice.impute.mean.r
+++ b/R/mice.impute.mean.r
@@ -26,5 +26,5 @@ mice.impute.mean <- function(y, ry, x = NULL, wy = NULL, ...)
 {
   if (is.null(wy))
     wy <- !ry
-  return(rep(mean(y[ry]), times = sum(wy)))
+  return(rep.int(mean(y[ry]), times = sum(wy)))
 }

--- a/R/mice.impute.midastouch.R
+++ b/R/mice.impute.midastouch.R
@@ -104,8 +104,8 @@ mice.impute.midastouch <- function(y, ry, x, wy = NULL, ridge = 1e-05,
   nobs <- sum(ry)
   nmis <- sum(wy)
   n <- length(ry)
-  obsind <- which(ry)
-  misind <- which(wy)
+  obsind <- ry
+  misind <- wy
   m <- ncol(X)
   yobs <- y[obsind]
   Xobs <- X[obsind, , drop = FALSE]
@@ -130,8 +130,8 @@ mice.impute.midastouch <- function(y, ry, x, wy = NULL, ridge = 1e-05,
   }
   
   # = check if any diagonal element is exactly zero ===========#
-  diag0 <- which(diag(XCX) == 0)  #==#
-  if (length(diag0) > 0) 
+  diag0 <- diag(XCX) == 0  #==#
+  if (any(diag0)) 
   {
     diag(XCX)[diag0] <- max(sminx, ridge)
   }  #==#
@@ -175,8 +175,8 @@ mice.impute.midastouch <- function(y, ry, x, wy = NULL, ridge = 1e-05,
     
     # = check if any diagonal element is exactly zero
     # =======================#
-    diag0 <- which(XXarray[ridgeind, ] == 0)  #==#
-    if (length(diag0) > 0) 
+    diag0 <- XXarray[ridgeind, ] == 0  #==#
+    if (any(diag0)) 
     {
       XXarray[ridgeind, ][diag0] <- max(sminx, ridge)
     }  #==#

--- a/R/mice.impute.rf.r
+++ b/R/mice.impute.rf.r
@@ -71,7 +71,7 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10, ...)
   xmis <- x[wy, , drop = FALSE]
   yobs <- y[ry]
   
-  forest <- sapply(1:ntree, FUN = function(s) onetree(xobs, xmis, yobs, ...))
+  forest <- sapply(seq_len(ntree), FUN = function(s) onetree(xobs, xmis, yobs, ...))
   if (nmis == 1) forest <- array(forest, dim = c(1, ntree))
   impute <- apply(forest, MARGIN = 1, FUN = function(s) sample(unlist(s), 1))
   return(impute)

--- a/R/mice.impute.ri.r
+++ b/R/mice.impute.ri.r
@@ -30,7 +30,7 @@ mice.impute.ri <- function(y, ry, x, wy = NULL, ri.maxit = 10, ...)
   xr <- xy
   y.dot <- y
   y.dot[wy] <- mice.impute.sample(y, ry, wy = wy)
-  for (k in 1:ri.maxit) {
+  for (k in seq_len(ri.maxit)) {
     r.dot <- .r.draw(y.dot, ry, xr, ...)
     y.dot <- .y.draw(y, ry, r.dot, xy, wy, ...)
   }
@@ -51,7 +51,7 @@ mice.impute.ri <- function(y, ry, x, wy = NULL, ri.maxit = 10, ...)
   p <- 1/(1 + exp(-(xr %*% psi.star)))
   vec <- (runif(nrow(p)) <= p)
   vec[vec] <- 1
-  rdot <- vec[1:n]
+  rdot <- vec[seq_len(n)]
   return(rdot)
 }
 
@@ -59,7 +59,7 @@ mice.impute.ri <- function(y, ry, x, wy = NULL, ri.maxit = 10, ...)
 .y.draw <- function(y, ry, rdot, xy, wy, ...)
 {
   parm <- .norm.draw(y, ry, cbind(xy, rdot), ...)
-  if (all(rdot[ry] == 1) | all(rdot[ry] == 0)) parm$coef[length(parm$coef)] <- 0
+  if (all(rdot[ry] == 1) || all(rdot[ry] == 0)) parm$coef[length(parm$coef)] <- 0
   ydot <- y
   rydot <- as.logical(rdot)
   ydot[wy] <- xy[wy, , drop = FALSE] %*% parm$beta[-length(parm$coef),] + 

--- a/R/mice.mids.r
+++ b/R/mice.mids.r
@@ -77,8 +77,7 @@ mice.mids <- function(obj, maxit = 1, diagnostics = TRUE, printFlag = TRUE,
     p <- padModel(obj$data, obj$method, obj$predictorMatrix, obj$visitSequence, 
                   obj$post, obj$nmis, nvar) else p <- obj$pad
   r <- (!is.na(p$data))
-  imp <- vector("list", ncol(p$data))
-  for (j in obj$visitSequence) imp[[j]] <- obj$imp[[j]]
+  imp <- lapply(seq_len(ncol(p$data)), function(j) obj$imp[[j]])
   assign(".Random.seed", obj$lastSeedValue, pos = 1)
   
   ## OK. Iterate.
@@ -89,22 +88,22 @@ mice.mids <- function(obj, maxit = 1, diagnostics = TRUE, printFlag = TRUE,
   for (j in p$visitSequence) p$data[(!r[, j]), j] <- NA
   
   ## delete data and imputations of automatic dummy variables
-  data <- p$data[, 1:nvar]
-  imp <- q$imp[1:nvar]
+  data <- p$data[, seq_len(nvar)]
+  imp <- q$imp[seq_len(nvar)]
   names(imp) <- varnames
   
   ## combine with previous chainMean and chainVar
   nvis <- length(obj$visitSequence)
   vnames <- varnames[obj$visitSequence]
   chainMean <- chainVar <- array(0, dim = c(nvis, to, obj$m), dimnames = list(vnames, 
-                                                                              1:to, paste("Chain", 1:obj$m)))
-  for (j in 1:nvis) {
+                                                                              seq_len(to), paste("Chain", seq_len(obj$m))))
+  for (j in seq_len(nvis)) {
     if (obj$iteration == 0) {
       chainMean[j, , ] <- q$chainMean[j, , ]
       chainVar[j, , ] <- q$chainVar[j, , ]
     } else {
-      chainMean[j, 1:obj$iteration, ] <- obj$chainMean[j, , ]
-      chainVar[j, 1:obj$iteration, ] <- obj$chainVar[j, , ]
+      chainMean[j, seq_len(obj$iteration), ] <- obj$chainMean[j, , ]
+      chainVar[j, seq_len(obj$iteration), ] <- obj$chainVar[j, , ]
       chainMean[j, from:to, ] <- q$chainMean[j, , ]
       chainVar[j, from:to, ] <- q$chainVar[j, , ]
     }
@@ -113,7 +112,7 @@ mice.mids <- function(obj, maxit = 1, diagnostics = TRUE, printFlag = TRUE,
   if (!state$log) 
     loggedEvents <- NULL
   if (state$log) 
-    row.names(loggedEvents) <- 1:nrow(loggedEvents)
+    row.names(loggedEvents) <- seq_len(nrow(loggedEvents))
   
   ## save, and return
   midsobj <- list(call = call, data = as.data.frame(data), where = obj$where, 

--- a/R/mice.mids.r
+++ b/R/mice.mids.r
@@ -77,7 +77,8 @@ mice.mids <- function(obj, maxit = 1, diagnostics = TRUE, printFlag = TRUE,
     p <- padModel(obj$data, obj$method, obj$predictorMatrix, obj$visitSequence, 
                   obj$post, obj$nmis, nvar) else p <- obj$pad
   r <- (!is.na(p$data))
-  imp <- lapply(seq_len(ncol(p$data)), function(j) obj$imp[[j]])
+  imp <- vector("list", ncol(p$data))
+  for (j in obj$visitSequence) imp[[j]] <- obj$imp[[j]]
   assign(".Random.seed", obj$lastSeedValue, pos = 1)
   
   ## OK. Iterate.

--- a/R/mice.r
+++ b/R/mice.r
@@ -239,7 +239,7 @@ mice <- function(data, m = 5,
   call <- match.call()
   if (!is.na(seed)) 
     set.seed(seed)
-  if (!(is.matrix(data) | is.data.frame(data)))
+  if (!(is.matrix(data) || is.data.frame(data)))
     stop("Data should be a matrix or data frame")
   nvar <- ncol(data)
   if (nvar < 2)
@@ -248,7 +248,7 @@ mice <- function(data, m = 5,
   nmis <- apply(is.na(data), 2, sum)
   varnames <- colnames(data)
   
-  if (!(is.matrix(where) | is.data.frame(where)))
+  if (!(is.matrix(where) || is.data.frame(where)))
     stop("Argument `where` not a matrix or data frame")
   if (!all(dim(data) == dim(where)))
     stop("Arguments `data` and `where` not of same size")
@@ -304,7 +304,7 @@ mice <- function(data, m = 5,
       dimnames(imp[[j]]) <- list(row.names(data)[wy], 1:m)
       if (method[j] != "") {
         # for incomplete variables that are imputed
-        for (i in 1:m) {
+        for (i in seq_len(m)) {
           if (nmis[j] < nrow(data)) {
             if (is.null(data.init)) {
               imp[[j]][, i] <- mice.impute.sample(y, ry, wy = wy, ...)
@@ -324,11 +324,11 @@ mice <- function(data, m = 5,
   
   ## restore the original NA's in the data
   for (j in p$visitSequence) {
-    p$data[(!r[, j]), j] <- NA
+    p$data[!r[, j], j] <- NA
   }
 
   ## delete data and imputations of automatic dummy variables
-  imp <- q$imp[1:nvar]
+  imp <- q$imp[seq_len(nvar)]
   names(imp) <- varnames
   names(method) <- varnames
   names(form) <- varnames
@@ -337,10 +337,10 @@ mice <- function(data, m = 5,
   if (!state$log)
     loggedEvents <- NULL
   if (state$log)
-    row.names(loggedEvents) <- 1:nrow(loggedEvents)
+    row.names(loggedEvents) <- seq_len(nrow(loggedEvents))
   
   ## save, and return
-  midsobj <- list(call = call, data = as.data.frame(p$data[, 1:nvar]), 
+  midsobj <- list(call = call, data = as.data.frame(p$data[, seq_len(nvar)]), 
                   where = where, m = m,
                   nmis = nmis, imp = imp, method = method,
                   predictorMatrix = predictorMatrix,

--- a/R/mids2mplus.r
+++ b/R/mids2mplus.r
@@ -31,21 +31,21 @@ mids2mplus <- function(imp, file.prefix="imp", path=getwd(), sep="\t", dec=".", 
 	m <- imp$m
 	file.list <- matrix(0,m,1)
 	script 	  <- matrix(0,3,1)
-	for (i in 1:m){
-		write.table(complete(imp,i), paste(path,"/",file.prefix,i,".dat", sep=""), sep=sep, dec=dec, col.names=F, row.names=F)
-		file.list[i,] <- paste(file.prefix,i,".dat", sep="")
+	for (i in seq_len(m)){
+		write.table(complete(imp,i), file.path(path, paste0(file.prefix, i, ".dat")), sep=sep, dec=dec, col.names=FALSE, row.names=FALSE)
+		file.list[i,] <- paste0(file.prefix,i,".dat")
 	}
-	write.table(file.list, paste(path,"/",file.prefix,"list.dat", sep=""), sep=sep, dec=dec, col.names=F, row.names=F, quote=F)
+	write.table(file.list, file.path(path, paste0(file.prefix,"list.dat")), sep=sep, dec=dec, col.names=FALSE, row.names=FALSE, quote=FALSE)
 	names <- paste(colnames(complete(imp, 1)), collapse=" ")
-	script[1,] <- paste("DATA: FILE IS ",file.prefix,"list.dat;", sep="")
+	script[1,] <- paste0("DATA: FILE IS ",file.prefix,"list.dat;")
 	script[2,] <- "TYPE = IMPUTATION;"
-	script[3,] <- paste("VARIABLE: NAMES ARE ",names,";", sep="")
-	write.table(script, paste(path,"/",file.prefix,"list.inp", sep=""), sep=sep, dec=dec, col.names=F, row.names=F, quote=F)
+	script[3,] <- paste0("VARIABLE: NAMES ARE ",names,";")
+	write.table(script, file.path(path,paste0(file.prefix,"list.inp")), sep=sep, dec=dec, col.names=FALSE, row.names=FALSE, quote=FALSE)
 
 	if (!silent) {
-    	cat("Data values written to", paste(path,"/",file.prefix,1,".dat", sep=""),"through", paste(file.prefix,m,".dat", sep=""), "\n")
-    	cat("Data  names written to", paste(path,"/",file.prefix,"list.dat", sep=""), "\n")
-    	cat("Mplus  code written to", paste(path,"/",file.prefix,"list.inp", sep=""), "\n")
+    	cat("Data values written to", file.path(path,paste0(file.prefix,1,".dat")),"through", paste0(file.prefix,m,".dat"), "\n")
+    	cat("Data  names written to", file.path(path,paste0(file.prefix,"list.dat")), "\n")
+    	cat("Mplus  code written to", file.path(path,paste0(file.prefix,"list.inp")), "\n")
     }
 }
 

--- a/R/mids2spss.r
+++ b/R/mids2spss.r
@@ -66,7 +66,7 @@ mids2spss <- function(imp, filedat="midsdata.txt", filesps="readmids.sps",
         varlabels <- names(df)
         if (is.null(varnames)) {
             varnames <- abbreviate(names(df), 8L)
-            if (any(vapply(varnames, nchar, numeric(1)) > 8L)) 
+            if (any(nchar(varnames) > 8L)) 
                 stop("I cannot abbreviate the variable names to eight or fewer letters")
             if (any(varnames != varlabels)) 
                 warning("some variable names were abbreviated")

--- a/R/mids2spss.r
+++ b/R/mids2spss.r
@@ -58,26 +58,26 @@ mids2spss <- function(imp, filedat="midsdata.txt", filesps="readmids.sps",
     miceWriteForeignSPSS <- function (df, datafile, codefile, varnames = NULL, dec=".", sep="\t") 
     {
         ##adapted version of writeForeignSPSS from foreign package to write mids-objects
-        adQuote <- function (x) paste("\"", x, "\"", sep = "")
+        adQuote <- function (x) paste0("\"", x, "\"")
         dfn <- lapply(df, function(x) if (is.factor(x)) as.numeric(x) else x)
-        eol <- paste(sep,"\n",sep="")
+        eol <- paste0(sep,"\n")
         write.table(dfn, file = datafile, row.names = FALSE, col.names = FALSE, 
                     sep = sep, dec = dec, quote = FALSE, na = "", eol=eol)
         varlabels <- names(df)
         if (is.null(varnames)) {
             varnames <- abbreviate(names(df), 8L)
-            if (any(sapply(varnames, nchar) > 8L)) 
+            if (any(vapply(varnames, nchar, numeric(1)) > 8L)) 
                 stop("I cannot abbreviate the variable names to eight or fewer letters")
             if (any(varnames != varlabels)) 
                 warning("some variable names were abbreviated")
         }
         varnames <- gsub("[^[:alnum:]_\\$@#]", "\\.", varnames)
         dl.varnames <- varnames
-        if (any(chv <- sapply(df, is.character))) {
-            lengths <- sapply(df[chv], function(v) max(nchar(v)))
+        if (any(chv <- vapply(df, is.character, logical(1)))) {
+            lengths <- vapply(df[chv], function(v) max(nchar(v)), numeric(1))
             if (any(lengths > 255L)) 
                 stop("Cannot handle character variables longer than 255")
-            lengths <- paste("(A", lengths, ")", sep = "")
+            lengths <- paste0("(A", lengths, ")")
             star <- ifelse(c(FALSE, diff(which(chv) > 1L)), " *", 
                            " ")
             dl.varnames[chv] <- paste(star, dl.varnames[chv], lengths)
@@ -90,13 +90,13 @@ mids2spss <- function(imp, filedat="midsdata.txt", filesps="readmids.sps",
         cat("VARIABLE LABELS\n", file = codefile, append = TRUE)
         cat(" ",paste(varnames, adQuote(varlabels), "\n"), ".\n", file = codefile, 
             append = TRUE)
-        factors <- sapply(df, is.factor)
+        factors <- vapply(df, is.factor, logical(1))
         if (any(factors)) {
             cat("\nVALUE LABELS\n", file = codefile, append = TRUE)
             for (v in which(factors)) {
                 cat(" /", varnames[v], "\n", file = codefile, append = TRUE)
                 levs <- levels(df[[v]])
-                for (u in 1:length(levs)) 
+                for (u in seq_along(levs)) 
                     cat(paste("  ",seq_along(levs)[u], adQuote(levs)[u], sep = " "), 
                         file = codefile, append = TRUE, fill=60)
             }

--- a/R/padmodel.R
+++ b/R/padmodel.R
@@ -5,15 +5,15 @@ padModel <- function(data, method, predictorMatrix, visitSequence,
   # visitSequence.  Returns a list whose components make up the padded model.
   
   categories <- data.frame(
-    is.factor = factor(rep(FALSE, nvar), levels = c("TRUE", "FALSE")), 
-    n.dummy   = rep(0, nvar), 
-    is.dummy  = factor(rep(FALSE, nvar), levels = c("TRUE", "FALSE")), 
-    father    = rep(0, nvar))
+    is.factor = factor(rep.int(FALSE, nvar), levels = c("TRUE", "FALSE")), 
+    n.dummy   = rep.int(0, nvar), 
+    is.dummy  = factor(rep.int(FALSE, nvar), levels = c("TRUE", "FALSE")), 
+    father    = rep.int(0, nvar))
   
   # make explicit local copy
   data <- data
   
-  for (j in 1:nvar) {
+  for (j in seq_len(nvar)) {
     if (is.factor(data[, j]) && any(predictorMatrix[, j] != 0)) {
       
       categories[j, 1] <- TRUE
@@ -32,19 +32,19 @@ padModel <- function(data, method, predictorMatrix, visitSequence,
                                       ncol = n.dummy))
       
       # remove j as predictor
-      predictorMatrix[1:nvar, j] <- rep(0, times = nvar)
-      form <- c(form, rep("", n.dummy))
+      predictorMatrix[seq_len(nvar), j] <- rep.int(0, times = nvar)
+      form <- c(form, rep.int("", n.dummy))
       
       if (any(visitSequence == j)) {
         # make column j a predictor for its dummies
         idx <- (ncol(predictorMatrix) - n.dummy + 1):ncol(predictorMatrix)
-        predictorMatrix[idx, j] <- rep(1, times = n.dummy)
+        predictorMatrix[idx, j] <- rep.int(1, times = n.dummy)
         
         # extend visitSequence
         newcol <- ncol(predictorMatrix) - n.dummy + 1
         nloops <- sum(visitSequence == j)
-        for (ii in 1:nloops) {
-          idx2 <- (1:length(visitSequence))[visitSequence == j][ii]
+        for (ii in seq_len(nloops)) {
+          idx2 <- seq_along(visitSequence)[visitSequence == j][ii]
           visitSequence <- append(visitSequence, newcol, idx2)
         }
       }
@@ -61,19 +61,19 @@ padModel <- function(data, method, predictorMatrix, visitSequence,
       data[!is.na(data[, j]), idx] <- model.matrix(~ cat.column - 1)[, -1]
       
       # name new columns
-      names(data)[idx] <- paste(attr(data, "names")[j], (1:n.dummy), sep = ".")
+      names(data)[idx] <- paste(attr(data, "names")[j], seq_len(n.dummy), sep = ".")
       
       # extend method and post arrays
-      method <- c(method, rep("dummy", n.dummy))
-      post <- c(post, rep("", n.dummy))
+      method <- c(method, rep.int("dummy", n.dummy))
+      post <- c(post, rep.int("", n.dummy))
       
       # append administrative info
       categories <- rbind(
         categories, 
-        data.frame(is.factor = rep(FALSE, n.dummy), 
-                   n.dummy   = rep(0, n.dummy), 
-                   is.dummy  = rep(TRUE, n.dummy), 
-                   father    = rep(j, n.dummy)))
+        data.frame(is.factor = rep.int(FALSE, n.dummy), 
+                   n.dummy   = rep.int(0, n.dummy), 
+                   is.dummy  = rep.int(TRUE, n.dummy), 
+                   father    = rep.int(j, n.dummy)))
     }
   }
   
@@ -85,7 +85,7 @@ padModel <- function(data, method, predictorMatrix, visitSequence,
   names(visitSequence) <- varnames[visitSequence]
   dimnames(categories)[[1]] <- dimnames(data)[[2]]
   
-  if (any(duplicated(names(data))))
+  if (anyDuplicated(names(data)))
     stop("Column names of padded data not unique")
   
   return(list(data = as.data.frame(data), 

--- a/R/plot.r
+++ b/R/plot.r
@@ -44,19 +44,17 @@ plot.mids <- function(x, y = NULL, theme = mice.theme(), layout = c(2, 3), type 
     
     ## create formula if not given in y
     if (missing(y)) {
-        formula <- as.formula(paste(paste(varlist, collapse = "+", sep = ""), "~.it|.ms", sep = ""))
+        formula <- as.formula(paste0(paste0(varlist, collapse = "+"), "~.it|.ms"))
     } else {
         formula <- NULL
         if (is.null(y)) 
-            formula <- as.formula(paste(paste(varlist, collapse = "+", sep = ""), "~.it|.ms", sep = ""))
-        if (class(y) == "character") {
-            if (length(y) == 1) 
-                formula <- as.formula(paste(y, "~.it|.ms", sep = "")) else formula <- as.formula(paste(paste(y, collapse = "+", sep = ""), "~.it|.ms", sep = ""))
+            formula <- as.formula(paste0(paste0(varlist, collapse = "+"), "~.it|.ms"))
+        if (is.character(y)) {
+                formula <- if (length(y) == 1) as.formula(paste0(y, "~.it|.ms")) else as.formula(paste0(paste0(y, collapse = "+"), "~.it|.ms"))
         }
-        if (class(y) == "integer" | class(y) == "logical") {
+        if (is.integer(y) || is.logical(y)) {
             vars <- varlist[y]
-            if (length(vars) == 1) 
-                formula <- as.formula(paste(vars, "~.it|.ms", sep = "")) else formula <- as.formula(paste(paste(vars, collapse = "+", sep = ""), "~.it|.ms", sep = ""))
+                formula <- if (length(vars) == 1) as.formula(paste0(vars, "~.it|.ms")) else as.formula(paste0(paste0(vars, collapse = "+"), "~.it|.ms"))
         }
         if (is.null(formula)) 
             formula <- as.formula(y)
@@ -67,7 +65,7 @@ plot.mids <- function(x, y = NULL, theme = mice.theme(), layout = c(2, 3), type 
     mn <- matrix(aperm(mn, c(2, 3, 1)), nrow = m * it)
     sm <- matrix(aperm(sm, c(2, 3, 1)), nrow = m * it)
     
-    adm <- expand.grid(1:it, 1:m, c("mean", "sd"))
+    adm <- expand.grid(seq_len(it), seq_len(m), c("mean", "sd"))
     data <- cbind(adm, rbind(mn, sm))
     colnames(data) <- c(".it", ".m", ".ms", varlist)
     .m <- NULL

--- a/R/pool.compare.r
+++ b/R/pool.compare.r
@@ -112,7 +112,7 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     call <- match.call()
     meth <- match.arg(tolower(method), c("wald", "likelihood"))
     
-    if (!is.mira(fit1) | !is.mira(fit0)) 
+    if (!is.mira(fit1) || !is.mira(fit0)) 
         stop("fit1 and fit0 should both have class 'mira'.\n")
     m1 <- length(fit1$analyses)
     m0 <- length(fit0$analyses)
@@ -132,7 +132,7 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     vars1 = names(est1$qbar)
     vars0 = names(est0$qbar)
     
-    if (is.null(vars1) | is.null(vars0)) 
+    if (is.null(vars1) || is.null(vars0)) 
       stop("coefficients do not have names")
     if (dimQ2 < 1) 
         stop("The larger model should be specified first and must be strictly larger than the smaller model.\n")
@@ -142,7 +142,7 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
     if (meth == "wald") {
         # Reference: paragraph 2.2, Article Meng & Rubin, Biometrika, 1992.  When two objects are to be compared we need to
         # calculate the matrix Q.
-        Q <- diag(rep(1, dimQ1), ncol = dimQ1)
+        Q <- diag(rep.int(1, dimQ1), ncol = dimQ1)
         where_new_vars = which(!(vars1 %in% vars0))
         Q <- Q[where_new_vars, , drop = FALSE]
         qbar <- Q %*% est1$qbar
@@ -157,7 +157,7 @@ pool.compare <- function(fit1, fit0, data = NULL, method = "Wald") {
             stop("For method=likelihood the imputed data set (a mids object) should be included.\n")
         
         devM <- devL <- 0
-        for (i in (1:m)) {
+        for (i in seq_len(m)) {
             # Calculate for each imputed dataset the deviance between the two models with the pooled coefficients.
             devL <- devL + LLlogistic(formula1, complete(data, i), est1$qbar) - LLlogistic(formula0, complete(data, i), est0$qbar)
             # Calculate for each imputed dataset the deviance between the two models with its estimated coefficients.

--- a/R/pool.r
+++ b/R/pool.r
@@ -96,10 +96,10 @@ pool <- function (object, method = "smallsample")
   }
   analyses <- getfit(object)
   
-  if (class(fa)[1]=="lme" &  
+  if (class(fa)[1]=="lme" &&
       !requireNamespace("nlme", quietly = TRUE))
     stop("Package 'nlme' needed fo this function to work. Please install it.", call. = FALSE)
-  if ((class(fa)[1]=="mer" | class(fa)[1] == "lmerMod" | inherits(fa,"merMod")) &  
+  if ((class(fa)[1]=="mer" || class(fa)[1] == "lmerMod" || inherits(fa,"merMod")) &&  
       !requireNamespace("lme4", quietly = TRUE))
     stop("Package 'lme4' needed fo this function to work. Please install it.", call. = FALSE)
   
@@ -110,7 +110,7 @@ pool <- function (object, method = "smallsample")
   mess <- try(vcov(fa), silent=TRUE)
   if (inherits(mess,"try-error")) stop("Object has no vcov() method.")
   
-  if (class(fa)[1]=="mer" | class(fa)[1] == "lmerMod" | inherits(fa,"merMod"))  # 14jun2014
+  if (class(fa)[1]=="mer" || class(fa)[1] == "lmerMod" || inherits(fa,"merMod"))  # 14jun2014
   { 
     k <- length(lme4::fixef(fa))
     names <- names(lme4::fixef(fa))
@@ -126,13 +126,13 @@ pool <- function (object, method = "smallsample")
     names <- names(coef(fa))
   }
   
-  qhat <- matrix(NA, nrow = m, ncol = k, dimnames = list(1:m, names))
-  u <- array(NA, dim = c(m, k, k), dimnames = list(1:m, names,
+  qhat <- matrix(NA, nrow = m, ncol = k, dimnames = list(seq_len(m), names))
+  u <- array(NA, dim = c(m, k, k), dimnames = list(seq_len(m), names,
                                                    names))
   
   ###   Fill arrays
   
-  for (i in 1:m) {
+  for (i in seq_len(m)) {
     fit <- analyses[[i]]
     if (class(fit)[1] == "mer")
     {
@@ -141,7 +141,7 @@ pool <- function (object, method = "smallsample")
       if (ncol(ui)!=ncol(qhat)) stop("Different number of parameters: class mer, fixef(fit): ",ncol(qhat),", as.matrix(vcov(fit)): ", ncol(ui))
       u[i, ,] <- array(ui, dim = c(1, dim(ui)))
     }
-    else if (class(fit)[1] == "lmerMod" | inherits(fa,"merMod"))
+    else if (class(fit)[1] == "lmerMod" || inherits(fa,"merMod"))
     {
       qhat[i,] <- lme4::fixef(fit)
       ui <- vcov(fit)

--- a/R/pool.r.squared.r
+++ b/R/pool.r.squared.r
@@ -83,7 +83,7 @@ pool.r.squared <- function(object, adjusted = FALSE) {
     table <- array(((exp(2 * fit$qbar) - 1)/(1 + exp(2 * fit$qbar)))^2, dim = c(1, 4))
     
     if (!adjusted) 
-        dimnames(table) <- list("R^2", c("est", "lo 95", "hi 95", "fmi")) else dimnames(table) <- list("adj R^2", c("est", "lo 95", "hi 95", "fmi"))
+    dimnames(table) <- if (!adjusted) list("R^2", c("est", "lo 95", "hi 95", "fmi")) else list("adj R^2", c("est", "lo 95", "hi 95", "fmi"))
     
     table[, 2] <- ((exp(2 * (fit$qbar - 1.96 * sqrt(fit$t))) - 1)/(1 + exp(2 * (fit$qbar - 1.96 * sqrt(fit$t)))))^2
     table[, 3] <- ((exp(2 * (fit$qbar + 1.96 * sqrt(fit$t))) - 1)/(1 + exp(2 * (fit$qbar + 1.96 * sqrt(fit$t)))))^2

--- a/R/pool.r.squared.r
+++ b/R/pool.r.squared.r
@@ -82,7 +82,6 @@ pool.r.squared <- function(object, adjusted = FALSE) {
     # Make table with results.
     table <- array(((exp(2 * fit$qbar) - 1)/(1 + exp(2 * fit$qbar)))^2, dim = c(1, 4))
     
-    if (!adjusted) 
     dimnames(table) <- if (!adjusted) list("R^2", c("est", "lo 95", "hi 95", "fmi")) else list("adj R^2", c("est", "lo 95", "hi 95", "fmi"))
     
     table[, 2] <- ((exp(2 * (fit$qbar - 1.96 * sqrt(fit$t))) - 1)/(1 + exp(2 * (fit$qbar - 1.96 * sqrt(fit$t)))))^2

--- a/R/pool.r.squared.r
+++ b/R/pool.r.squared.r
@@ -68,12 +68,11 @@ pool.r.squared <- function(object, adjusted = FALSE) {
     # Set up array r2 to store R2 values, Fisher z-transformations of R2 values and its variance.
     analyses <- object$analyses
     m <- length(analyses)
-    r2 <- matrix(NA, nrow = m, ncol = 3, dimnames = list(1:m, c("R^2", "Fisher trans F^2", "se()")))
+    r2 <- matrix(NA, nrow = m, ncol = 3, dimnames = list(seq_len(m), c("R^2", "Fisher trans F^2", "se()")))
     # Fill arrays
-    for (i in 1:m) {
+    for (i in seq_len(m)) {
         fit <- analyses[[i]]
-        if (adjusted == FALSE) 
-            r2[i, 1] <- sqrt(summary(fit)$r.squared) else r2[i, 1] <- sqrt(summary(fit)$adj.r.squared)
+        r2[i, 1] <- if (!adjusted) sqrt(summary(fit)$r.squared) else sqrt(summary(fit)$adj.r.squared)
         r2[i, 2] <- 0.5 * log((r2[i, 1] + 1)/(1 - r2[i, 1]))
         r2[i, 3] <- 1/(length(summary(fit)$residuals) - 3)
     }
@@ -83,7 +82,7 @@ pool.r.squared <- function(object, adjusted = FALSE) {
     # Make table with results.
     table <- array(((exp(2 * fit$qbar) - 1)/(1 + exp(2 * fit$qbar)))^2, dim = c(1, 4))
     
-    if (adjusted == FALSE) 
+    if (!adjusted) 
         dimnames(table) <- list("R^2", c("est", "lo 95", "hi 95", "fmi")) else dimnames(table) <- list("adj R^2", c("est", "lo 95", "hi 95", "fmi"))
     
     table[, 2] <- ((exp(2 * (fit$qbar - 1.96 * sqrt(fit$t))) - 1)/(1 + exp(2 * (fit$qbar - 1.96 * sqrt(fit$t)))))^2

--- a/R/quickpred.r
+++ b/R/quickpred.r
@@ -90,7 +90,7 @@ quickpred <- function(data, mincor = 0.1, minpuc = 0, include = "", exclude = ""
     # automatic predictor selection according to Van Buuren et al (1999)
     
     # argument checking
-    if (!(is.matrix(data) | is.data.frame(data))) 
+    if (!(is.matrix(data) || is.data.frame(data))) 
         stop("Data should be a matrix or data frame")
     if ((nvar <- ncol(data)) < 2) 
         stop("Data should contain at least two columns")

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -138,23 +138,23 @@ rbind.mids <- function(x, y = NULL, ...) {
       stop("Number of imputations differ")
     
     warned <- FALSE
-    if (!identical(x$method, y$method) & !warned) {
+    if (!identical(x$method, y$method) && !warned) {
       warning("`methods` not equal; ignores y$method")
       warned <- TRUE
     }
-    if (!identical(x$predictorMatrix, y$predictorMatrix) & !warned) {
+    if (!identical(x$predictorMatrix, y$predictorMatrix) && !warned) {
       warning("`predictorMatrix` not equal; ignores y$predictorMatrix")
       warned <- TRUE
     }
-    if (!identical(x$visitSequence, y$visitSequence) & !warned) {
+    if (!identical(x$visitSequence, y$visitSequence) && !warned) {
       warning("`visitSequence` not equal; ignores y$visitSequence")
       warned <- TRUE
     }
-    if (!identical(x$post, y$post) & !warned) {
+    if (!identical(x$post, y$post) && !warned) {
       warning("`post` not equal; ignores y$post")
       warned <- TRUE
     }
-    if (!identical(x$pad$categories, y$pad$categories) & !warned) {
+    if (!identical(x$pad$categories, y$pad$categories) && !warned) {
       warning("`pad$categories` not equal; ignores y$pad")
       warned <- TRUE
     }
@@ -185,8 +185,8 @@ rbind.mids <- function(x, y = NULL, ...) {
     
     # The original data of y will be binded into the multiple imputed dataset, including the imputed values of y.
     imp <- vector("list", ncol(x$data))
-    for (j in 1:ncol(x$data)) {
-      if(!is.null(x$imp[[j]]) | !is.null(y$imp[[j]])) {
+    for (j in seq_len(ncol(x$data))) {
+      if(!is.null(x$imp[[j]]) || !is.null(y$imp[[j]])) {
         imp[[j]] <- rbind(x$imp[[j]], y$imp[[j]])
       }
     }

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -12,7 +12,7 @@ sampler <- function(p, data, where, m, imp, r, visitSequence, fromto, printFlag,
   if (maxit > 0)
     chainVar <- chainMean <- array(0, dim = c(length(visitSequence), maxit, m), 
                                    dimnames = list(dimnames(data)[[2]][visitSequence], 
-                                                   1:maxit, paste("Chain", 1:m)))
+                                                   seq_len(maxit), paste("Chain", seq_len(m))))
   
   ## THE ITERATION MAIN LOOP: GIBBS SAMPLER
   if (maxit < 1) iteration <- 0 
@@ -22,7 +22,7 @@ sampler <- function(p, data, where, m, imp, r, visitSequence, fromto, printFlag,
     for (k in from:to) {
       # begin k loop : main iteration loop
       iteration <- k
-      for (i in 1:m) {
+      for (i in seq_len(m)) {
         # begin i loop: repeated imputation loop
         if (printFlag)
           cat("\n ", iteration, " ", i)
@@ -51,14 +51,14 @@ sampler <- function(p, data, where, m, imp, r, visitSequence, fromto, printFlag,
           newstate <- list(it = k, im = i, co = j, dep = vname, meth = theMethod, log = oldstate$log)
           assign("state", newstate, pos = parent.frame(), inherits = TRUE)
           
-          if (printFlag & theMethod != "dummy")
+          if (printFlag && theMethod != "dummy")
             cat(" ", vname)
           
           # switching logic: flat, mult, pass, dumm
           empt <- theMethod == ""
-          elem <- !empt & !is.passive(theMethod) & theMethod != "dummy"
-          flat <- elem & substring(tolower(theMethod), 1, 2) != "2l"
-          pass <- !empt & is.passive(theMethod)
+          elem <- !empt && !is.passive(theMethod) && theMethod != "dummy"
+          flat <- elem && substring(tolower(theMethod), 1, 2) != "2l"
+          pass <- !empt && is.passive(theMethod)
           dumm <- theMethod == "dummy"
           
           # standard imputation
@@ -120,14 +120,14 @@ sampler <- function(p, data, where, m, imp, r, visitSequence, fromto, printFlag,
       # store means and sd of m imputes
       k2 <- k - from + 1
       if (length(visitSequence) > 0) {
-        for (j in 1:length(visitSequence)) {
+        for (j in seq_along(visitSequence)) {
           jj <- visitSequence[j]
           if (!is.factor(data[, jj])) {
             chainVar[j, k2, ] <- apply(imp[[jj]], 2, var, na.rm = TRUE)
             chainMean[j, k2, ] <- colMeans(as.matrix(imp[[jj]]), na.rm = TRUE)
           }
           if (is.factor(data[, jj])) {
-            for (mm in 1:m) {
+            for (mm in seq_len(m)) {
               nc <- as.integer(factor(imp[[jj]][, mm], levels = levels(data[, jj])))
               chainVar[j, k2, mm] <- var(nc, na.rm = TRUE)
               chainMean[j, k2, mm] <- mean(nc, na.rm = TRUE)

--- a/R/squeeze.r
+++ b/R/squeeze.r
@@ -15,7 +15,7 @@
 #'@return A vector of length \code{length(x)}.
 #'@author Stef van Buuren, 2011.
 #'@export
-squeeze <- function(x, bounds = c(min(x[r]), max(x[r])), r = rep(TRUE, length(x))) {
+squeeze <- function(x, bounds = c(min(x[r]), max(x[r])), r = repint(TRUE, length(x))) {
     if (length(r) != length(x)) 
         stop("Different length of vectors x and r")
     x[x < bounds[1]] <- bounds[1]

--- a/R/squeeze.r
+++ b/R/squeeze.r
@@ -15,7 +15,7 @@
 #'@return A vector of length \code{length(x)}.
 #'@author Stef van Buuren, 2011.
 #'@export
-squeeze <- function(x, bounds = c(min(x[r]), max(x[r])), r = repint(TRUE, length(x))) {
+squeeze <- function(x, bounds = c(min(x[r]), max(x[r])), r = rep.int(TRUE, length(x))) {
     if (length(r) != length(x)) 
         stop("Different length of vectors x and r")
     x[x < bounds[1]] <- bounds[1]

--- a/R/stripplot.r
+++ b/R/stripplot.r
@@ -211,14 +211,14 @@ stripplot.mids <- function(x,
                  horizontal = horizontal)
     
     ## create formula if not given (in call$data !)
-    vnames <- names(cd)[-(1:2)]
-    allfactors <- unlist(lapply(cd,is.factor))[-(1:2)]
+    vnames <- names(cd)[-seq_len(2)]
+    allfactors <- unlist(lapply(cd,is.factor))[-seq_len(2)]
     if (missing(data)) {
         vnames <- vnames[!allfactors]
-        formula <- as.formula(paste(paste(vnames,collapse="+",sep=""),"~.imp",sep=""))
+        formula <- as.formula(paste0(paste0(vnames,collapse="+"),"~.imp"))
     } else {
         ## pad abbreviated formula
-        abbrev <- length(grep("~", call$data))==0
+        abbrev <- ! any(grepl("~", call$data))
         if (abbrev) {
             if (length(call$data)>1) stop("Cannot pad extended formula.")
             else formula <- as.formula(paste(call$data,"~.imp",sep=""))
@@ -237,7 +237,7 @@ stripplot.mids <- function(x,
     
     ## calculate selection vector gp
     nona <- is.null(call$na.groups)
-    if (!is.null(call$groups) & nona) gp <- call$groups
+    if (!is.null(call$groups) && nona) gp <- call$groups
     else {
         if (nona) {
             na.df <- r[, ynames, drop=FALSE]
@@ -248,7 +248,7 @@ stripplot.mids <- function(x,
     }
     
     ## change axis defaults of extended formula interface
-    if (is.null(call$xlab) & !is.na(match(".imp",xnames))) {
+    if (is.null(call$xlab) && !is.na(match(".imp",xnames))) {
         dots$xlab <- ""
         if (length(xnames)==1) dots$xlab <- "Imputation number"
     }

--- a/R/summary.r
+++ b/R/summary.r
@@ -17,7 +17,7 @@ summary.mira <- function(object, ...) {
     # This summary function is for a mira object.  Then the seperate analyses are of class lm (glm), it calls sequentially
     # summary.lm (summary.glm) for all analyses.  KO, 4/2/00
     
-    for (i in (1:length(object$analyses))) {
+    for (i in seq_along(object$analyses)) {
         cat("\n", "## summary of imputation", i, ":\n")
         print(summary(object$analyses[[i]], ...), ...)
     }
@@ -50,7 +50,7 @@ summary.mipo <- function(object, ...) {
         2 * (1 - pt(abs(table[, 3]), x$df)) else NA
     table[, 6] <- table[, 1] - qt(0.975, x$df) * table[, 2]
     table[, 7] <- table[, 1] + qt(0.975, x$df) * table[, 2]
-    if (is.null(x$nmis) | is.null(names(x$qbar)))
+    if (is.null(x$nmis) || is.null(names(x$qbar)))
         table[, 8] <- NA else table[, 8] <- x$nmis[names(x$qbar)]
     table[, 9] <- x$fmi
     table[, 10] <- x$lambda

--- a/R/validate.arguments.R
+++ b/R/validate.arguments.R
@@ -1,9 +1,9 @@
 validate.arguments <- function(y, ry, x, wy, allow.x.NULL = FALSE, 
                                allow.x.NA = FALSE) {
   # validate standard arguments of mice.impute functions
-  if (!allow.x.NULL & is.null(x)) 
+  if (!allow.x.NULL && is.null(x)) 
     stop("Cannot handle NULL value for `x`")
-  if (!allow.x.NA & anyNA(x)) 
+  if (!allow.x.NA && anyNA(x)) 
     stop("Cannot handle NA in `x`")
   if (!is.vector(ry)) 
     stop("`ry` is not a vector")

--- a/R/with.r
+++ b/R/with.r
@@ -51,15 +51,17 @@ with.mids <- function(data, expr, ...) {
     call <- match.call()
     if (!is.mids(data)) 
         stop("The data must have class mids")
-    analyses <- as.list(1:data$m)
     
-    # do the repeated analysis, store the result.
-    for (i in 1:data$m) {
-        data.i <- complete(data, i)
-        analyses[[i]] <- eval(expr = substitute(expr), envir = data.i, enclos = parent.frame())
-        if (is.expression(analyses[[i]])) 
-            analyses[[i]] <- eval(expr = analyses[[i]], envir = data.i, enclos = parent.frame())
+    f <- function(i) {
+      data.i <- complete(data, i)
+      res <- eval(expr = substitute(expr), envir = data.i, enclos = parent.frame())
+      if (is.expression(res)) 
+        res <- eval(expr = analyses[[i]], envir = data.i, enclos = parent.frame())
+      res
     }
+    
+    analyses <- lapply(seq_len(data$m), f)
+    
     # return the complete data analyses as a list of length nimp
     object <- list(call = call, call1 = data$call, nmis = data$nmis, analyses = analyses)
     # formula=formula(analyses[[1]]$terms))

--- a/R/with.r
+++ b/R/with.r
@@ -59,9 +59,7 @@ with.mids <- function(data, expr, ...) {
         res <- eval(expr = analyses[[i]], envir = data.i, enclos = parent.frame())
       res
     }
-    
     analyses <- lapply(seq_len(data$m), f)
-    
     # return the complete data analyses as a list of length nimp
     object <- list(call = call, call1 = data$call, nmis = data$nmis, analyses = analyses)
     # formula=formula(analyses[[1]]$terms))

--- a/R/with.r
+++ b/R/with.r
@@ -51,15 +51,15 @@ with.mids <- function(data, expr, ...) {
     call <- match.call()
     if (!is.mids(data)) 
         stop("The data must have class mids")
+    analyses <- as.list(seq_len(data$m))
     
-    f <- function(i) {
+    # do the repeated analysis, store the result.
+    for (i in seq_along(analyses)) {
       data.i <- complete(data, i)
-      res <- eval(expr = substitute(expr), envir = data.i, enclos = parent.frame())
-      if (is.expression(res)) 
-        res <- eval(expr = analyses[[i]], envir = data.i, enclos = parent.frame())
-      res
+      analyses[[i]] <- eval(expr = substitute(expr), envir = data.i, enclos = parent.frame())
+      if (is.expression(analyses[[i]])) 
+        analyses[[i]] <- eval(expr = analyses[[i]], envir = data.i, enclos = parent.frame())
     }
-    analyses <- lapply(seq_len(data$m), f)
     # return the complete data analyses as a list of length nimp
     object <- list(call = call, call1 = data$call, nmis = data$nmis, analyses = analyses)
     # formula=formula(analyses[[1]]$terms))

--- a/R/xyplot.mads.R
+++ b/R/xyplot.mads.R
@@ -49,7 +49,7 @@ xyplot.mads <- function(x, data, which.pat = NULL,
   }
   if (is.null(which.pat)) {
     pat <- nrow(x$patterns)
-    which.pat <- c(1:pat)
+    which.pat <- seq_len(pat)
   } else {
     pat <- length(which.pat)
   }
@@ -61,7 +61,7 @@ xyplot.mads <- function(x, data, which.pat = NULL,
     xlab <- "Data values in pattern"
   }
   data <- NULL
-  for (i in 1:pat){
+  for (i in seq_len(pat)){
     can <- which(x$cand == which.pat[i])
     mis <- matrix(NA, nrow = length(can), ncol = 3)
     nc <- which(x$patterns[which.pat[i], ] == 0)
@@ -72,15 +72,13 @@ xyplot.mads <- function(x, data, which.pat = NULL,
       mis[is.na(x$amp[can, nc]), 1] <- 1
       mis[is.na(mis[, 1]), 1] <- 0
     }
-    mis[, 2] <- rep(which.pat[i], length(can))
+    mis[, 2] <- rep.int(which.pat[i], length(can))
     mis[, 3] <- unname(x$scores[[which.pat[i]]])
     data <- rbind(data, cbind(mis, dat[can, ]))
   }
   colnames(data) <- c(".amp", ".pat", "scores", names(x$data))
   data$.amp <- factor(data$.amp, levels = c(0, 1))
-  formula = as.formula(paste("scores ~ ", 
-                             paste(varlist, collapse = "+", sep = ""),
-                             sep = ""))
+  formula = as.formula(paste0("scores ~ ", paste0(varlist, collapse = "+")))
   if (is.null(layout)) {
     if (length(varlist) > 6) {
       layout <- c(3, 3)
@@ -99,8 +97,8 @@ xyplot.mads <- function(x, data, which.pat = NULL,
   key <- list(columns = 2, points = list(col = colors, pch = 1), 
               text = list(c("Non-Amputed Data", "Amputed Data")))
   
-  p <- list()
-  for (i in 1:pat) {
+  p <- setNames(vector(mode = "list", length = pat), paste("Scatterplot Pattern", which.pat))
+  for (i in seq_len(pat)) {
     p[[paste("Scatterplot Pattern", which.pat[i])]] <- 
       xyplot(x = formula, data = data[data$.pat == which.pat[i], ],
              groups = data$.amp, par.settings = theme,

--- a/R/xyplot.mads.R
+++ b/R/xyplot.mads.R
@@ -97,7 +97,7 @@ xyplot.mads <- function(x, data, which.pat = NULL,
   key <- list(columns = 2, points = list(col = colors, pch = 1), 
               text = list(c("Non-Amputed Data", "Amputed Data")))
   
-  p <- setNames(vector(mode = "list", length = pat), paste("Scatterplot Pattern", which.pat))
+  p <- stats::setNames(vector(mode = "list", length = pat), paste("Scatterplot Pattern", which.pat))
   for (i in seq_len(pat)) {
     p[[paste("Scatterplot Pattern", which.pat[i])]] <- 
       xyplot(x = formula, data = data[data$.pat == which.pat[i], ],

--- a/R/xyplot.r
+++ b/R/xyplot.r
@@ -182,13 +182,13 @@ xyplot.mids <- function(x,
     
     ## calculate selection vector gp
     nona <- is.null(call$na.groups)
-    if (!is.null(call$groups) & nona) gp <- call$groups
+    if (!is.null(call$groups) && nona) gp <- call$groups
     else {
         if (nona) {
             na.df <- r[, ynames, drop=FALSE]
-            gp <- unlist(lapply(na.df, rep, x$m+1))
+            gp <- unlist(lapply(na.df, rep.int, x$m+1))
         } else {
-            gp <- rep(nagp, length(ynames)*(x$m+1))
+            gp <- rep.int(nagp, length(ynames)*(x$m+1))
         }
     }
     

--- a/man/squeeze.Rd
+++ b/man/squeeze.Rd
@@ -4,7 +4,7 @@
 \alias{squeeze}
 \title{Squeeze the imputed values to be within specified boundaries.}
 \usage{
-squeeze(x, bounds = c(min(x[r]), max(x[r])), r = rep(TRUE, length(x)))
+squeeze(x, bounds = c(min(x[r]), max(x[r])), r = rep.int(TRUE, length(x)))
 }
 \arguments{
 \item{x}{A numerical vector with values}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 
 // matcher
 IntegerVector matcher(NumericVector obs, NumericVector mis, int k);
-RcppExport SEXP mice_matcher(SEXP obsSEXP, SEXP misSEXP, SEXP kSEXP) {
+RcppExport SEXP _mice_matcher(SEXP obsSEXP, SEXP misSEXP, SEXP kSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;

--- a/tests/testthat/test-as.mids.R
+++ b/tests/testthat/test-as.mids.R
@@ -25,11 +25,11 @@ rev <- ncol(X):1
 test6 <- as.mids(X[, rev])
 
 test_that("as.mids() produces a `mids` object", {
-  expect_true(is.mids(test1))
-  expect_true(is.mids(test2))
-  expect_true(is.mids(test3))
-  expect_true(is.mids(test4))
-  expect_true(is.mids(test5))
+  expect_is(test1, "mids")
+  expect_is(test2, "mids")
+  expect_is(test3, "mids")
+  expect_is(test4, "mids")
+  expect_is(test5, "mids")
 })
 
 test_that("complete() reproduces the original data", {

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -4,8 +4,8 @@ nhanes_mids <- mice(nhanes, m = 2, print = FALSE)
 nhanes_complete <- complete(nhanes_mids)
 
 test_that("No missing values remain in imputed nhanes data set", {
-  expect_true(sum(is.na(nhanes)) > 0)
-  expect_true(sum(is.na(nhanes_complete)) == 0)
+  expect_gt(sum(is.na(nhanes)), 0)
+  expect_equal(sum(is.na(nhanes_complete)), 0)
 })
 
 # where

--- a/tests/testthat/test-mice.impute.2lonly.mean.R
+++ b/tests/testthat/test-mice.impute.2lonly.mean.R
@@ -12,8 +12,8 @@ wy4 <- rep(c(TRUE, FALSE), times = c(1, length(y) - 1))
 type <- c(1, -2, 1)
 
 test_that("Returns requested length", {
-  expect_true(length(mice.impute.2lonly.mean(y, ry, x, type, wy1)) == sum(wy1))
-  expect_true(length(mice.impute.2lonly.mean(y, ry, x, type, wy2)) == sum(wy2))
-  expect_true(length(mice.impute.2lonly.mean(y, ry, x, type, wy3)) == sum(wy3))
-  expect_true(length(mice.impute.2lonly.mean(y, ry, x, type, wy4)) == sum(wy4))
+  expect_equal(length(mice.impute.2lonly.mean(y, ry, x, type, wy1)), sum(wy1))
+  expect_equal(length(mice.impute.2lonly.mean(y, ry, x, type, wy2)), sum(wy2))
+  expect_equal(length(mice.impute.2lonly.mean(y, ry, x, type, wy3)), sum(wy3))
+  expect_equal(length(mice.impute.2lonly.mean(y, ry, x, type, wy4)), sum(wy4))
 })

--- a/tests/testthat/test-mice.impute.pmm.R
+++ b/tests/testthat/test-mice.impute.pmm.R
@@ -12,10 +12,10 @@ wy3 <- rep(FALSE, length(y))
 wy4 <- rep(c(TRUE, FALSE), times = c(1, length(y) - 1))
 
 test_that("Returns requested length", {
-  expect_true(length(mice.impute.pmm(y, ry, x)) == sum(!ry))
-  expect_true(length(mice.impute.pmm(y, ry, x, wy = wy1)) == sum(wy1))
-  expect_true(length(mice.impute.pmm(y, ry, x, wy = wy2)) == sum(wy2))
-  expect_true(length(mice.impute.pmm(y, ry, x, wy = wy3)) == sum(wy3))
-  expect_true(length(mice.impute.pmm(y, ry, x, wy = wy4)) == sum(wy4))
+  expect_equal(length(mice.impute.pmm(y, ry, x)), sum(!ry))
+  expect_equal(length(mice.impute.pmm(y, ry, x, wy = wy1)), sum(wy1))
+  expect_equal(length(mice.impute.pmm(y, ry, x, wy = wy2)), sum(wy2))
+  expect_equal(length(mice.impute.pmm(y, ry, x, wy = wy3)), sum(wy3))
+  expect_equal(length(mice.impute.pmm(y, ry, x, wy = wy4)), sum(wy4))
 })
 


### PR DESCRIPTION
This pull request does not change any functionality, but aims to improve the efficiency and robustness of the package.  It seeks to accomplish the following:

* Tests
    + prefer more specific tests than `expect_true` when possible
* R scripts
    + use logical vectors as-is in logical tests, without using `==`
    + prefer `file.path` over `paste` when constructing file names
    + favor `vapply` over `sapply`
    + use double logical operators in `if` statements where a length-one result is desired
    + prefer `paste0` over `paste(..., sep = "")`
    + avoid `which` when the original logical vector will suffice
    + preallocate vectors before loops in order to avoid growing them inside loops
    + favor `*.int` internal functions over more abstracted versions, e.g. `rep.int` over `rep`
    + use `*apply` functions when possible instead of a `for` loop
    + prefer `seq_len` and `seq_along` over `1:*`
    + only use `ifelse` when a vectorized comparison is desired; use `if` and `else` otherwise