### PR TITLE
md.pattern() for incomplete and complete data

### DIFF
--- a/R/md.pattern.r
+++ b/R/md.pattern.r
@@ -53,12 +53,24 @@ md.pattern <- function(x, plot = TRUE){
   sortR <- R[order(pat), ] #sort rowwise
   mpat <- sortR[!duplicated(sortR), ]
   #update row and column margins
-  rownames(mpat) <- table(pat)
+  if (all(!is.na(x))){
+    cat(" /\\     /\\\n{  `---'  }\n{  O   O  }\n==>  V <==") 
+    cat("  No need for mice. This data set is completely observed.\n")
+    cat(" \\  \\|/  /\n  `-----'\n\n")
+    mpat <- t(as.matrix(mpat, byrow = TRUE))
+    rownames(mpat) <- table(pat)
+  } else {
+    rownames(mpat) <- table(pat)
+  }
   r <- cbind(abs(mpat - 1), rowSums(mpat))
   r <- rbind(r, c(nmis[order(nmis)], sum(nmis)))
   if (plot){ #add plot
     plot.new()
-    R <- r[1:nrow(r)-1, 1:ncol(r)-1]
+    if (all(!is.na(x))){
+      R <- t(as.matrix(r[1:nrow(r)-1, 1:ncol(r)-1]))
+    } else {
+      R <- r[1:nrow(r)-1, 1:ncol(r)-1]
+    }
     par(mar=rep(0, 4))
     plot.window(xlim=c(-1, ncol(R) + 1), ylim=c(-1, nrow(R) + 1), asp=1)
     M <- cbind(c(row(R)), c(col(R))) - 1


### PR DESCRIPTION
This commit updates `md.pattern()` to allow for complete data sets. When a complete data set is served, `md.pattern()` will return:

1. the complete data pattern (a single row)
2. a plot of the complete data pattern
3. a message indicating that the data set is completely observed

This PR solves #83 
