### PR TITLE
Bugfix: algorithm stops when method is specified, but predictor relations are empty

### DIFF
--- a/R/sampler.R
+++ b/R/sampler.R
@@ -49,7 +49,7 @@ sampler <- function(data, m, where, imp, blocks, method, visitSequence,
           
           # univariate/multivariate logic
           theMethod <- method[h]
-          empt <- theMethod == ""
+          empt <- theMethod == "" | all(predictorMatrix[h, ] == 0) 
           univ <- !empt && !is.passive(theMethod) && 
             !handles.format(paste0("mice.impute.", theMethod))
           mult <- !empt && !is.passive(theMethod) && 


### PR DESCRIPTION
This solves #96. 

A column is now excluded from imputation if an imputation method is provided while the predictor relations are user-specified as empty. This conforms to the following behaviour:

| Method specified | Predictors specified | Parsed to sampler? | Scenario |
| ------------- | ------------- | ------------- | ------------- |
| Yes  | Yes  | Yes | Default or correct user-specification|
| No  | Yes  | No | `method` indicates no imputation |
| Yes  | No  | No | unable to impute because of custom [misspecified?] `predictorMatrix` |
| No  | No  | No | Default or correct user-specification|
