### PR TITLE
Consistent parameter estimation throughout the norm family

### DIFF
--- a/R/mice.impute.norm.R
+++ b/R/mice.impute.norm.R
@@ -72,7 +72,6 @@ norm.draw <- function(y, ry, x, rank.adjust = TRUE, ...)
 .norm.draw <- function (y, ry, x, rank.adjust = TRUE, ...){
   p <- estimice(x[ry, , drop = FALSE], y[ry], ...)
   sigma.star <- sqrt(sum((p$r)^2)/rchisq(1, p$df))
-  #beta.star <- p$c + (t(chol(sym(p$v), pivot = TRUE)) %*% rnorm(ncol(x))) * sigma.star
   beta.star <- p$c + (t(chol(sym(p$v))) %*% rnorm(ncol(x))) * sigma.star
   parm <- list(p$c, beta.star, sigma.star, p$ls.meth)
   names(parm) <- c("coef", "beta", "sigma", "estimation")

--- a/R/mice.impute.norm.boot.R
+++ b/R/mice.impute.norm.boot.R
@@ -19,24 +19,15 @@
 #'@family univariate imputation functions
 #'@keywords datagen
 #'@export
-mice.impute.norm.boot <- function(y, ry, x, wy = NULL, ridge = 1e-05, ...) {
+mice.impute.norm.boot <- function(y, ry, x, wy = NULL, ...) {
   if (is.null(wy)) wy <- !ry
   x <- cbind(1, as.matrix(x))
-  xobs <- x[ry, ]
-  yobs <- y[ry]
   n1 <- sum(ry)
   s <- sample(n1, n1, replace = TRUE)
-  dotxobs <- xobs[s, ]
-  dotyobs <- yobs[s]
-  xtx <- t(dotxobs) %*% dotxobs
-  pen <- ridge * diag(xtx)
-  if (length(pen) == 1) 
-    pen <- matrix(pen)
-  v <- solve(xtx + diag(pen))
-  coef <- t(dotyobs %*% dotxobs %*% v)
-  residuals <- dotyobs - dotxobs %*% coef
-  sigma <- sqrt((sum(residuals^2))/(n1 - ncol(x) - 1))
-  parm <- list(coef, sigma)
-  names(parm) <- c("beta", "sigma")
-  return(x[wy, ] %*% parm$beta + rnorm(sum(wy)) * parm$sigma)
+  ss<-s
+  dotxobs <- x[ry, , drop = FALSE][s, ]
+  dotyobs <- y[ry][s]
+  p <- estimice(dotxobs, dotyobs, ...)
+  sigma <- sqrt((sum(p$r^2))/(n1 - ncol(x) - 1))
+  return(x[wy, ] %*% p$c + rnorm(sum(wy)) * sigma)
 }

--- a/R/mice.impute.norm.boot.R
+++ b/R/mice.impute.norm.boot.R
@@ -8,10 +8,8 @@
 #'\code{sum(wy)}
 #'@details
 #'Draws a bootstrap sample from \code{x[ry,]} and \code{y[ry]}, calculates
-#'regression weights and imputes with normal residuals. The \code{ridge}
-#'parameter adds a penalty term \code{ridge*diag(xtx)} to the
-#'variance-covariance matrix \code{xtx}.
-#'@author Stef van Buuren
+#'regression weights and imputes with normal residuals. 
+#'@author Gerko Vink, Stef van Buuren, 2018
 #'@references Van Buuren, S., Groothuis-Oudshoorn, K. (2011). \code{mice}:
 #'Multivariate Imputation by Chained Equations in \code{R}. \emph{Journal of
 #'Statistical Software}, \bold{45}(3), 1-67.

--- a/R/mice.impute.norm.nob.R
+++ b/R/mice.impute.norm.nob.R
@@ -22,7 +22,7 @@
 #'@section Warning: The function does not incorporate the variability of the
 #'regression weights, so it is not 'proper' in the sense of Rubin. For small
 #'samples, variability of the imputed data is therefore underestimated.
-#'@author Stef van Buuren, Karin Groothuis-Oudshoorn, 2000
+#'@author Gerko Vink, Stef van Buuren, Karin Groothuis-Oudshoorn, 2018
 #'@seealso \code{\link{mice}}, \code{\link{mice.impute.norm}}
 #'@references Van Buuren, S., Groothuis-Oudshoorn, K. (2011). \code{mice}:
 #'Multivariate Imputation by Chained Equations in \code{R}. \emph{Journal of
@@ -42,7 +42,7 @@ mice.impute.norm.nob <- function(y, ry, x, wy = NULL, ...) {
   return(x[wy, ] %*% parm$beta + rnorm(sum(wy)) * parm$sigma)
 }
 
-.norm.fix <- function(y, ry, x, ridge = 1e-05, ...) {
+.norm.fix <- function(y, ry, x, ...) {
   p <- estimice(x[ry, , drop = FALSE], y[ry], ...)
   sigma <- sqrt((sum(p$r^2))/(sum(ry) - ncol(x) - 1))
   parm <- list(p$c, sigma)

--- a/R/mice.impute.norm.nob.R
+++ b/R/mice.impute.norm.nob.R
@@ -43,17 +43,9 @@ mice.impute.norm.nob <- function(y, ry, x, wy = NULL, ...) {
 }
 
 .norm.fix <- function(y, ry, x, ridge = 1e-05, ...) {
-  xobs <- x[ry, ]
-  yobs <- y[ry]
-  xtx <- t(xobs) %*% xobs
-  pen <- ridge * diag(xtx)
-  if (length(pen) == 1) 
-    pen <- matrix(pen)
-  v <- solve(xtx + diag(pen))
-  coef <- t(yobs %*% xobs %*% v)
-  residuals <- yobs - xobs %*% coef
-  sigma <- sqrt((sum(residuals^2))/(sum(ry) - ncol(x) - 1))
-  parm <- list(coef, sigma)
+  p <- estimice(x[ry, , drop = FALSE], y[ry], ...)
+  sigma <- sqrt((sum(p$r^2))/(sum(ry) - ncol(x) - 1))
+  parm <- list(p$c, sigma)
   names(parm) <- c("beta", "sigma")
   return(parm)
 }

--- a/R/mice.impute.norm.predict.R
+++ b/R/mice.impute.norm.predict.R
@@ -35,16 +35,9 @@
 #'@family univariate imputation functions
 #'@keywords datagen
 #'@export
-mice.impute.norm.predict <- function(y, ry, x, wy = NULL, ridge = 1e-05, ...) {
+mice.impute.norm.predict <- function(y, ry, x, wy = NULL, ...) {
   if (is.null(wy)) wy <- !ry
   x <- cbind(1, as.matrix(x))
-  xobs <- x[ry, , drop = FALSE]
-  yobs <- y[ry]
-  xtx <- t(xobs) %*% xobs
-  pen <- ridge * diag(xtx)
-  if (length(pen) == 1) 
-    pen <- matrix(pen)
-  v <- solve(xtx + diag(pen))
-  coef <- t(yobs %*% xobs %*% v)
-  return(x[wy, , drop = FALSE] %*% coef)
+  p <- estimice(x[ry, , drop = FALSE], y[ry], ...)
+  return(x[wy, , drop = FALSE] %*% p$c)
 }

--- a/R/mice.impute.norm.predict.R
+++ b/R/mice.impute.norm.predict.R
@@ -9,8 +9,7 @@
 #'\code{sum(wy)}
 #'@details
 #'Calculates regression weights from the observed data and returns predicted
-#'values to as imputations. The \code{ridge} parameter adds a penalty term
-#'\code{ridge*diag(xtx)} to the variance-covariance matrix \code{xtx}. This
+#'values to as imputations. This
 #'method is known as \emph{regression imputation}.
 #'@section Warning: THIS METHOD SHOULD NOT BE USED FOR DATA ANALYSIS. 
 #'This method is seductive because it imputes the most 
@@ -24,7 +23,7 @@
 #'At best, prediction can give reasonable estimates of the mean, especially 
 #'if normality assumptions are plausible. See Little and Rubin (2002, p. 62-64)
 #'or Van Buuren (2012, p. 11-13, p. 45-46) for a discussion of this method. 
-#'@author Stef van Buuren, 2011
+#'@author Gerko Vink, Stef van Buuren, 2018
 #'@references 
 #'Little, R.J.A. and Rubin, D.B. (2002). Statistical Analysis with Missing 
 #'Data.  New York: John Wiley and Sons.

--- a/man/mice.impute.norm.boot.Rd
+++ b/man/mice.impute.norm.boot.Rd
@@ -5,7 +5,7 @@
 \alias{norm.boot}
 \title{Imputation by linear regression, bootstrap method}
 \usage{
-mice.impute.norm.boot(y, ry, x, wy = NULL, ridge = 1e-05, ...)
+mice.impute.norm.boot(y, ry, x, wy = NULL, ...)
 }
 \arguments{
 \item{y}{Vector to be imputed}
@@ -21,13 +21,6 @@ model is fitted. The \code{ry} generally distinguishes the observed
 \item{wy}{Logical vector of length \code{length(y)}. A \code{TRUE} value 
 indicates locations in \code{y} for which imputations are created.}
 
-\item{ridge}{The ridge penalty used in \code{.norm.draw()} to prevent 
-problems with multicollinearity. The default is \code{ridge = 1e-05}, 
-which means that 0.01 percent of the diagonal is added to the cross-product. 
-Larger ridges may result in more biased estimates. For highly noisy data 
-(e.g. many junk variables), set \code{ridge = 1e-06} or even lower to 
-reduce bias. For highly collinear data, set \code{ridge = 1e-04} or higher.}
-
 \item{...}{Other named arguments.}
 }
 \value{
@@ -39,9 +32,7 @@ Imputes univariate missing data using linear regression with bootstrap
 }
 \details{
 Draws a bootstrap sample from \code{x[ry,]} and \code{y[ry]}, calculates
-regression weights and imputes with normal residuals. The \code{ridge}
-parameter adds a penalty term \code{ridge*diag(xtx)} to the
-variance-covariance matrix \code{xtx}.
+regression weights and imputes with normal residuals.
 }
 \references{
 Van Buuren, S., Groothuis-Oudshoorn, K. (2011). \code{mice}:
@@ -67,6 +58,6 @@ Other univariate imputation functions: \code{\link{mice.impute.cart}},
   \code{\link{mice.impute.ri}}
 }
 \author{
-Stef van Buuren
+Gerko Vink, Stef van Buuren, 2018
 }
 \keyword{datagen}

--- a/man/mice.impute.norm.predict.Rd
+++ b/man/mice.impute.norm.predict.Rd
@@ -5,7 +5,7 @@
 \alias{norm.predict}
 \title{Imputation by linear regression through prediction}
 \usage{
-mice.impute.norm.predict(y, ry, x, wy = NULL, ridge = 1e-05, ...)
+mice.impute.norm.predict(y, ry, x, wy = NULL, ...)
 }
 \arguments{
 \item{y}{Vector to be imputed}
@@ -21,13 +21,6 @@ model is fitted. The \code{ry} generally distinguishes the observed
 \item{wy}{Logical vector of length \code{length(y)}. A \code{TRUE} value 
 indicates locations in \code{y} for which imputations are created.}
 
-\item{ridge}{The ridge penalty used in \code{.norm.draw()} to prevent 
-problems with multicollinearity. The default is \code{ridge = 1e-05}, 
-which means that 0.01 percent of the diagonal is added to the cross-product. 
-Larger ridges may result in more biased estimates. For highly noisy data 
-(e.g. many junk variables), set \code{ridge = 1e-06} or even lower to 
-reduce bias. For highly collinear data, set \code{ridge = 1e-04} or higher.}
-
 \item{...}{Other named arguments.}
 }
 \value{
@@ -40,8 +33,7 @@ known as \emph{regression imputation}.
 }
 \details{
 Calculates regression weights from the observed data and returns predicted
-values to as imputations. The \code{ridge} parameter adds a penalty term
-\code{ridge*diag(xtx)} to the variance-covariance matrix \code{xtx}. This
+values to as imputations. This
 method is known as \emph{regression imputation}.
 }
 \section{Warning}{
@@ -85,6 +77,6 @@ Other univariate imputation functions: \code{\link{mice.impute.cart}},
   \code{\link{mice.impute.ri}}
 }
 \author{
-Stef van Buuren, 2011
+Gerko Vink, Stef van Buuren, 2018
 }
 \keyword{datagen}


### PR DESCRIPTION
Parameter estimation in `norm.boot`, `norm.nob` and `norm.pred` is now done with `mice::estimice()` instead of the deprecated ridge regression. 

