### PR TITLE
More efficient and consistent usage of parlmice

### DIFF
--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -27,93 +27,18 @@
 #'@aliases parlmice
 #'@param data A data frame or matrix containing the incomplete data. Similar to 
 #'the first argument of \code{\link{mice}}.
+#'@param m The number of desired imputated datasets. By default $m=5$ as with \code{mice}
+#'@param seed A scalar to be used as the seed value for the mice algorithm within 
+#'each parallel stream. Please note that the imputations will be the same for all 
+#'streams and, hence, this should be used if and only if \code{n.core = 1} and 
+#'if it is desired to obtain the same output as under \code{mice}. 
 #'@param n.core A scalar indicating the number of cores that should be used. 
 #'@param n.imp.core A scalar indicating the number of imputations per core. 
 #'@param cluster.seed A scalar to be used as the seed value. It is recommended to put the 
 #'seed value here and not outside this function, as otherwise the parallel processes
 #'will be performed with separate, random seeds. 
-#'@param m The number of desired imputated datasets. By default $m=5$ as with \code{mice}
 #'@param cl.type The cluster type. Default value is \code{"PSOCK"}. Posix machines (linux, Mac)
 #'generally benefit from much faster cluster computation if \code{type} is set to \code{type = "FORK"}. 
-#'@param seed A scalar to be used as the seed value for the mice algorithm within 
-#'each parallel stream. Please note that the imputations will be the same for all 
-#'streams and, hence, this should be used if and only if \code{n.core = 1} and 
-#'if it is desired to obtain the same output as under \code{mice}. 
-#'@param where A data frame or matrix with logicals of the same dimensions 
-#'as \code{data} indicating where in the data the imputations should be 
-#'created. The default, \code{where = is.na(data)}, specifies that the
-#'missing data should be imputed. The \code{where} argument may be used to 
-#'overimpute observed data, or to skip imputations for selected missing values.
-#'@param blocks List of vectors with variable names per block. List elements 
-#'may be named to identify blocks. Variables within a block are 
-#'imputed by a multivariate imputation method
-#'(see \code{method} argument). By default each variable is placed 
-#'into its own block, which is effectively
-#'fully conditional specification (FCS) by univariate models 
-#'(variable-by-variable imputation). Only variables whose names appear in 
-#'\code{blocks} are imputed. The relevant columns in the \code{where} 
-#'matrix are set to \code{FALSE} of variables that are not block members. 
-#'A variable may appear in multiple blocks. In that case, it is 
-#'effectively re-imputed each time that it is visited.
-#'@param method Can be either a single string, or a vector of strings with
-#'length \code{length(blocks)}, specifying the imputation method to be
-#'used for each column in data. If specified as a single string, the same
-#'method will be used for all blocks. The default imputation method (when no
-#'argument is specified) depends on the measurement level of the target column,
-#'as regulated by the \code{defaultMethod} argument. Columns that need
-#'not be imputed have the empty method \code{""}. See details.
-#'@param predictorMatrix A numeric matrix of \code{length(blocks)} rows 
-#'and \code{ncol(data)} columns, containing 0/1 data specifying 
-#'the set of predictors to be used for each target column.
-#'Each row corresponds to a variable block, i.e., a set of variables 
-#'to be imputed. A value of \code{1} means that the column
-#'variable is used as a predictor for the target block (in the rows). 
-#'By default, the \code{predictorMatrix} is a square matrix of \code{ncol(data)}
-#'rows and columns with all 1's, except for the diagonal. 
-#'Note: For two-level imputation models (which have \code{"2l"} in their names)
-#'other codes (e.g, \code{2} or \code{-2}) are also allowed.
-#'@param visitSequence A vector of block names of arbitrary length, specifying the
-#'sequence of blocks that are imputed during one iteration of the Gibbs 
-#'sampler. A block is a collection of variables. All variables that are 
-#'members of the same block are imputed 
-#'when the block is visited. A variable that is a member of multiple blocks 
-#'is re-imputed within the same iteration. 
-#'The default \code{visitSequence = "roman"} visits the blocks (left to right)
-#'in the order in which they appear in \code{blocks}. 
-#'One may also use one of the following keywords: \code{"arabic"} 
-#'(right to left), \code{"monotone"} (ordered low to high proportion 
-#'of missing data) and \code{"revmonotone"} (reverse of monotone). 
-#'@param formulas A named list of formula's, or expressions that
-#'can be converted into formula's by \code{as.formula}. List elements
-#'correspond to blocks. The block to which the list element applies is 
-#'identified by its name, so list names must correspond to block names.
-#'The \code{formulas} argument is an alternative to the 
-#'\code{predictorMatrix} argument that allows for more flexibility in 
-#'specifying imputation models, e.g., for specifying interaction terms. 
-#'@param blots A named \code{list} of \code{alist}'s that can be used 
-#'to pass down arguments to lower level imputation function. The entries
-#'of element \code{blots[[blockname]]} are passed down to the function
-#'called for block \code{blockname}.
-#'@param post A vector of strings with length \code{ncol(data)} specifying
-#'expressions as strings. Each string is parsed and 
-#'executed within the \code{sampler()} function to post-process 
-#'imputed values during the iterations. 
-#'The default is a vector of empty strings, indicating no post-processing.
-#'@param defaultMethod A vector of length 4 containing the default
-#'imputation methods for 1) numeric data, 2) factor data with 2 levels, 3) 
-#'factor data with > 2 unordered levels, and 4) factor data with > 2 
-#'ordered levels. By default, the method uses 
-#'\code{pmm}, predictive mean matching (numeric data) \code{logreg}, logistic
-#'regression imputation (binary data, factor with 2 levels) \code{polyreg},
-#'polytomous regression imputation for unordered categorical data (factor > 2
-#'levels) \code{polr}, proportional odds model for (ordered, > 2 levels).
-#'@param maxit A scalar giving the number of iterations. The default is 5.
-#'@param data.init A data frame of the same size and type as \code{data},
-#'without missing data, used to initialize imputations before the start of the
-#'iterative process.  The default \code{NULL} implies that starting imputation
-#'are created by a simple random draw from the data. Note that specification of
-#'\code{data.init} will start all \code{m} Gibbs sampling streams from the same
-#'imputation.
 #'@param ... Named arguments that are passed down to function \code{\link{mice}} or
 #'\code{\link{makeCluster}}. 
 #'
@@ -142,10 +67,8 @@
 #' }
 #' 
 #'@export
-parlmice <- function(data, m = 5, n.core = NULL, n.imp.core = NULL, cluster.seed = NA,  
-                     seed = NA, cl.type = "PSOCK", method, predictorMatrix, where, 
-                     blocks, visitSequence, formulas, blots, post, defaultMethod, 
-                     maxit, data.init, ...){ 
+parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL, 
+                     n.imp.core = NULL, cl.type = "PSOCK", ...){ 
   # check form of data and m
   data <- check.dataform(data)
   m <- check.m(m)
@@ -183,24 +106,14 @@ parlmice <- function(data, m = 5, n.core = NULL, n.imp.core = NULL, cluster.seed
   } 
   
   # create arguments to export to cluster
-  args <- match.call(mice)
+  args <- match.call(mice, expand.dots = TRUE, envir = parent.frame(2))
   args[[1]] <- NULL
-  args$data <- as.name("data")
   args$m <- n.imp.core
-  if(!missing(visitSequence)){args$visitSequence <- visitSequence}
-  if(!missing(method)){args$method <- method}
-  if(!missing(predictorMatrix)){args$predictorMatrix <- predictorMatrix}
-  if(!missing(where)){args$where <- where}
-  if(!missing(formulas)){args$formulas <- formulas}
-  if(!missing(blocks)){args$blocks <- blocks}
-  if(!missing(blots)){args$blots <- blots}
-  if(!missing(post)){args$post <- post}
-  if(!missing(data.init)){args$data.init <- data.init}
-  
+
   # make computing cluster
   cl <- parallel::makeCluster(n.core, type = cl.type)
   parallel::clusterExport(cl, 
-                          varlist = names(args), 
+                          varlist = c("data", ls(parent.frame())), 
                           envir = environment())
   parallel::clusterExport(cl, 
                           varlist = "do.call")
@@ -208,7 +121,7 @@ parlmice <- function(data, m = 5, n.core = NULL, n.imp.core = NULL, cluster.seed
   if (!is.na(cluster.seed)) {
     parallel::clusterSetRNGStream(cl, cluster.seed)
   }
-  
+
   # generate imputations
   imps <- parallel::parLapply(cl = cl, X = 1:n.core, function(x) do.call(mice, as.list(args), envir = environment()))
   parallel::stopCluster(cl)

--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -113,7 +113,9 @@ parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
   # make computing cluster
   cl <- parallel::makeCluster(n.core, type = cl.type)
   parallel::clusterExport(cl, 
-                          varlist = c("data", "m", "seed", ls(parent.frame())), 
+                          varlist = c("data", "m", "seed", "cluster.seed", 
+                                      "n.core", "n.imp.core", "cl.type",
+                                      ls(parent.frame())), 
                           envir = environment())
   parallel::clusterExport(cl, 
                           varlist = "do.call")

--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -106,14 +106,14 @@ parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
   } 
   
   # create arguments to export to cluster
-  args <- match.call(mice, expand.dots = TRUE, envir = parent.frame(2))
+  args <- match.call(mice, expand.dots = TRUE)
   args[[1]] <- NULL
   args$m <- n.imp.core
 
   # make computing cluster
   cl <- parallel::makeCluster(n.core, type = cl.type)
   parallel::clusterExport(cl, 
-                          varlist = c("data", ls(parent.frame())), 
+                          varlist = c("data", "m", "seed", ls(parent.frame())), 
                           envir = environment())
   parallel::clusterExport(cl, 
                           varlist = "do.call")

--- a/man/parlMICE.Rd
+++ b/man/parlMICE.Rd
@@ -4,10 +4,8 @@
 \alias{parlmice}
 \title{Wrapper function that runs MICE in parallel}
 \usage{
-parlmice(data, m = 5, n.core = NULL, n.imp.core = NULL,
-  cluster.seed = NA, seed = NA, cl.type = "PSOCK", method,
-  predictorMatrix, where, blocks, visitSequence, formulas, blots, post,
-  defaultMethod, maxit, data.init, ...)
+parlmice(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
+  n.imp.core = NULL, cl.type = "PSOCK", ...)
 }
 \arguments{
 \item{data}{A data frame or matrix containing the incomplete data. Similar to 
@@ -15,107 +13,21 @@ the first argument of \code{\link{mice}}.}
 
 \item{m}{The number of desired imputated datasets. By default $m=5$ as with \code{mice}}
 
-\item{n.core}{A scalar indicating the number of cores that should be used.}
-
-\item{n.imp.core}{A scalar indicating the number of imputations per core.}
-
-\item{cluster.seed}{A scalar to be used as the seed value. It is recommended to put the 
-seed value here and not outside this function, as otherwise the parallel processes
-will be performed with separate, random seeds.}
-
 \item{seed}{A scalar to be used as the seed value for the mice algorithm within 
 each parallel stream. Please note that the imputations will be the same for all 
 streams and, hence, this should be used if and only if \code{n.core = 1} and 
 if it is desired to obtain the same output as under \code{mice}.}
 
+\item{cluster.seed}{A scalar to be used as the seed value. It is recommended to put the 
+seed value here and not outside this function, as otherwise the parallel processes
+will be performed with separate, random seeds.}
+
+\item{n.core}{A scalar indicating the number of cores that should be used.}
+
+\item{n.imp.core}{A scalar indicating the number of imputations per core.}
+
 \item{cl.type}{The cluster type. Default value is \code{"PSOCK"}. Posix machines (linux, Mac)
 generally benefit from much faster cluster computation if \code{type} is set to \code{type = "FORK"}.}
-
-\item{method}{Can be either a single string, or a vector of strings with
-length \code{length(blocks)}, specifying the imputation method to be
-used for each column in data. If specified as a single string, the same
-method will be used for all blocks. The default imputation method (when no
-argument is specified) depends on the measurement level of the target column,
-as regulated by the \code{defaultMethod} argument. Columns that need
-not be imputed have the empty method \code{""}. See details.}
-
-\item{predictorMatrix}{A numeric matrix of \code{length(blocks)} rows 
-and \code{ncol(data)} columns, containing 0/1 data specifying 
-the set of predictors to be used for each target column.
-Each row corresponds to a variable block, i.e., a set of variables 
-to be imputed. A value of \code{1} means that the column
-variable is used as a predictor for the target block (in the rows). 
-By default, the \code{predictorMatrix} is a square matrix of \code{ncol(data)}
-rows and columns with all 1's, except for the diagonal. 
-Note: For two-level imputation models (which have \code{"2l"} in their names)
-other codes (e.g, \code{2} or \code{-2}) are also allowed.}
-
-\item{where}{A data frame or matrix with logicals of the same dimensions 
-as \code{data} indicating where in the data the imputations should be 
-created. The default, \code{where = is.na(data)}, specifies that the
-missing data should be imputed. The \code{where} argument may be used to 
-overimpute observed data, or to skip imputations for selected missing values.}
-
-\item{blocks}{List of vectors with variable names per block. List elements 
-may be named to identify blocks. Variables within a block are 
-imputed by a multivariate imputation method
-(see \code{method} argument). By default each variable is placed 
-into its own block, which is effectively
-fully conditional specification (FCS) by univariate models 
-(variable-by-variable imputation). Only variables whose names appear in 
-\code{blocks} are imputed. The relevant columns in the \code{where} 
-matrix are set to \code{FALSE} of variables that are not block members. 
-A variable may appear in multiple blocks. In that case, it is 
-effectively re-imputed each time that it is visited.}
-
-\item{visitSequence}{A vector of block names of arbitrary length, specifying the
-sequence of blocks that are imputed during one iteration of the Gibbs 
-sampler. A block is a collection of variables. All variables that are 
-members of the same block are imputed 
-when the block is visited. A variable that is a member of multiple blocks 
-is re-imputed within the same iteration. 
-The default \code{visitSequence = "roman"} visits the blocks (left to right)
-in the order in which they appear in \code{blocks}. 
-One may also use one of the following keywords: \code{"arabic"} 
-(right to left), \code{"monotone"} (ordered low to high proportion 
-of missing data) and \code{"revmonotone"} (reverse of monotone).}
-
-\item{formulas}{A named list of formula's, or expressions that
-can be converted into formula's by \code{as.formula}. List elements
-correspond to blocks. The block to which the list element applies is 
-identified by its name, so list names must correspond to block names.
-The \code{formulas} argument is an alternative to the 
-\code{predictorMatrix} argument that allows for more flexibility in 
-specifying imputation models, e.g., for specifying interaction terms.}
-
-\item{blots}{A named \code{list} of \code{alist}'s that can be used 
-to pass down arguments to lower level imputation function. The entries
-of element \code{blots[[blockname]]} are passed down to the function
-called for block \code{blockname}.}
-
-\item{post}{A vector of strings with length \code{ncol(data)} specifying
-expressions as strings. Each string is parsed and 
-executed within the \code{sampler()} function to post-process 
-imputed values during the iterations. 
-The default is a vector of empty strings, indicating no post-processing.}
-
-\item{defaultMethod}{A vector of length 4 containing the default
-imputation methods for 1) numeric data, 2) factor data with 2 levels, 3) 
-factor data with > 2 unordered levels, and 4) factor data with > 2 
-ordered levels. By default, the method uses 
-\code{pmm}, predictive mean matching (numeric data) \code{logreg}, logistic
-regression imputation (binary data, factor with 2 levels) \code{polyreg},
-polytomous regression imputation for unordered categorical data (factor > 2
-levels) \code{polr}, proportional odds model for (ordered, > 2 levels).}
-
-\item{maxit}{A scalar giving the number of iterations. The default is 5.}
-
-\item{data.init}{A data frame of the same size and type as \code{data},
-without missing data, used to initialize imputations before the start of the
-iterative process.  The default \code{NULL} implies that starting imputation
-are created by a simple random draw from the data. Note that specification of
-\code{data.init} will start all \code{m} Gibbs sampling streams from the same
-imputation.}
 
 \item{...}{Named arguments that are passed down to function \code{\link{mice}} or
 \code{\link{makeCluster}}.}

--- a/tests/testthat/test-parlmice.R
+++ b/tests/testthat/test-parlmice.R
@@ -43,32 +43,31 @@ test_that("n.core larger than logical CPU cores", {
 #   expect_warning(H <- parlmice(nhanes, n.imp.core = 3))
 #   expect_identical(H$m, 3 * (parallel::detectCores() - 1))
 # })
-
+# 
 # #Same cluster.seed - multiple cores
 # #Result: Imputations equal between parlmice instances
+# imp1 <- parlmice(nhanes, m=2, cluster.seed = 123)
+# imp2 <- parlmice(nhanes, m=2, cluster.seed = 123)
 # test_that("cluster.seed", {
-# imp1 <- parlmice(nhanes, m=4, cluster.seed = 123)
-# imp2 <- parlmice(nhanes, m=4, cluster.seed = 123)
 # expect_equal(imp1, imp2)
 # })
-
+# 
 # #Should run without failure
+# df <- boys
+# meth <- make.method(df)
+# pred <- make.predictorMatrix(df)
+# visit <- 9:1
+# imp3 <- parlmice(df, method = meth,
+#                 predictorMatrix = pred,
+#                 visitSequence = visit,
+#                 n.core = 2, 
+#                 n.imp.core = 4,
+#                 maxit = 3,
+#                 cluster.seed = 123)
 # test_that("Runs when overriding defaults", {
-#   set.seed(123)
-#   df <- boys
-#   meth <- make.method(df)
-#   pred <- make.predictorMatrix(df)
-#   visit <- sample(1:ncol(df))
-#   imp <- parlmice(df, method = meth, 
-#                   predictorMatrix = pred, 
-#                   visitSequence = visit, 
-#                   m = 2,
-#                   maxit = 3, 
-#                   cluster.seed = 123,
-#                   seed = 234)
-#   expect_identical(pred, imp$pred)
-#   expect_identical(imp$iteration, 3)
-#   expect_identical(imp$method, meth)
-#   expect_identical(imp$visitSequence, names(df)[visit])
-#   expect_identical(imp$m, 2*4)
+#   expect_identical(imp3$pred, pred)
+#   expect_identical(imp3$iteration, 3)
+#   expect_identical(imp3$method, meth)
+#   expect_identical(imp3$visitSequence, names(df)[visit])
+#   expect_identical(imp3$m, 2*4)
 # })

--- a/tests/testthat/test-parlmice.R
+++ b/tests/testthat/test-parlmice.R
@@ -26,8 +26,6 @@ test_that("Imputations are equal between mice and parlmice", {
 #Should return m = n.imp.core * parallel::detectCores() - 1
 # test_that("Warning because n.core not specified", {
 #   expect_warning(H <- parlmice(nhanes, n.imp.core = 3))
-# })
-# test_that("Cores not specified", {
 #   expect_identical(H$m, 3 * (parallel::detectCores() - 1))
 # })
 

--- a/tests/testthat/test-parlmice.R
+++ b/tests/testthat/test-parlmice.R
@@ -8,26 +8,11 @@ test_that("Warning and Imputations between mice and parlmice are unequal", {
 
 #Same seed - single core - 
 #Result: Imputations equal between mice and parlmice
-C <- parlmice(nhanes, n.core = 1, n.imp.core = 5, seed = 123)
-D <- mice(nhanes, m = 5, print = FALSE, seed = 123)
 test_that("Imputations are equal between mice and parlmice", {
+  C <- parlmice(nhanes, n.core = 1, n.imp.core = 5, seed = 123)
+  D <- mice(nhanes, m = 5, print = FALSE, seed = 123)
   expect_identical(complete(C, "long"), complete(D, "long"))
 })
-
-#Same cluster.seed - multiple cores
-#Result: Imputations equal between parlmice instances
-E <- parlmice(nhanes, n.core = 2, n.imp.core = 2, cluster.seed = 123)
-G <- parlmice(nhanes, n.core = 2, n.imp.core = 2, cluster.seed = 123)
-test_that("Imputations are equal between mice and parlmice", {
-  expect_equal(E, G)
-})
-
-#NOT RUN ON R CMD CHECK AND CRAN CHECK - TOO MANY PARALLEL PROCESSES SPAWNED
-#Should return m = n.imp.core * parallel::detectCores() - 1
-# test_that("Warning because n.core not specified", {
-#   expect_warning(H <- parlmice(nhanes, n.imp.core = 3))
-#   expect_identical(H$m, 3 * (parallel::detectCores() - 1))
-# })
 
 #Should return m = 8
 I <- parlmice(nhanes, n.core = 2, n.imp.core = 4)
@@ -52,3 +37,38 @@ test_that("n.core larger than logical CPU cores", {
   expect_error(parlmice(nhanes, n.core = parallel::detectCores() + 1))
 })
 
+# # NOT RUN ON R CMD CHECK AND CRAN CHECK - TOO MANY PARALLEL PROCESSES SPAWNED
+# # Should return m = n.imp.core * parallel::detectCores() - 1
+# test_that("Warning because n.core not specified", {
+#   expect_warning(H <- parlmice(nhanes, n.imp.core = 3))
+#   expect_identical(H$m, 3 * (parallel::detectCores() - 1))
+# })
+
+# #Same cluster.seed - multiple cores
+# #Result: Imputations equal between parlmice instances
+# test_that("cluster.seed", {
+# imp1 <- parlmice(nhanes, m=4, cluster.seed = 123)
+# imp2 <- parlmice(nhanes, m=4, cluster.seed = 123)
+# expect_equal(imp1, imp2)
+# })
+
+# #Should run without failure
+# test_that("Runs when overriding defaults", {
+#   set.seed(123)
+#   df <- boys
+#   meth <- make.method(df)
+#   pred <- make.predictorMatrix(df)
+#   visit <- sample(1:ncol(df))
+#   imp <- parlmice(df, method = meth, 
+#                   predictorMatrix = pred, 
+#                   visitSequence = visit, 
+#                   m = 2,
+#                   maxit = 3, 
+#                   cluster.seed = 123,
+#                   seed = 234)
+#   expect_identical(pred, imp$pred)
+#   expect_identical(imp$iteration, 3)
+#   expect_identical(imp$method, meth)
+#   expect_identical(imp$visitSequence, names(df)[visit])
+#   expect_identical(imp$m, 2*4)
+# })


### PR DESCRIPTION
Everything cf. [this wishlist](https://github.com/stefvanbuuren/mice/pull/107#issuecomment-398702780) in #107. 

- If arguments between `mice()` and `parlmice()` match, they are in the same order
- Defaults cf. `mice()`. [only `m=5`]
- No argument duplication. Everything parsed through `dots`.  