### PR TITLE
Solves `base::rbind()` issue when `method` is a list

### DIFF
--- a/R/method.R
+++ b/R/method.R
@@ -110,5 +110,5 @@ check.method <- function(method, data, where, blocks, defaultMethod) {
               call. = FALSE)
   }
   method[nimp == 0] <- ""
-  method
+  unlist(method)
 }


### PR DESCRIPTION
CHANGED added `unlist()` to the return in `check.method()`.

**Illustration of the problem**
When method is a list, e.g. 
```
meth <- make.method(mammalsleep)
meth <- as.list(meth)
```
this will generally have no different behaviour from `method` being a vector as `meth[i]` would yield the same result either way. However, when the system is computationally singular, the `loggedEvents` will be updated. Then, in that process, when `base::rbind()` is called it returns an error from the unexported `match.names()` function if `method` is a list. 