### PR TITLE
Fixed: 2l.norm does not run

### DIFF
--- a/R/mice.impute.2l.norm.R
+++ b/R/mice.impute.2l.norm.R
@@ -80,7 +80,7 @@ mice.impute.2l.norm <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
     
     symridge <- function(x, ridge = 0.0001, ...) {
       x <- (x + t(x))/2
-      x + diag(diag(x) * ridge, nrow = length(x))
+      x + diag(diag(x) * ridge)
     }
     
     ## append intercept


### PR DESCRIPTION
Line 83 was changed since `mice v2.46` to include argument `nrow = length(x)`. This breaks the ridge regression and stops the algorithm with the following error:

```
Error in x + diag(diag(x) * ridge, nrow = length(x)) : 
  non-conformable arrays
``` 

MWE:
```
#load data
con <- url("https://www.dropbox.com/s/xslcyncplv1a6su/popular.RData?dl=1")
load(con)

#set specs
pred <- make.predictorMatrix(popNCR3)
pred["extrav", ] <- c(0, -2, 0, 2, 2, 2, 2)  #2l.norm
pred["sex", ] <- c(0, 1, 1, 0, 1, 1, 1)  #2logreg
pred["texp", ] <- c(0, -2, 1, 1, 0, 1, 1)  #2lonly.mean
pred["popular", ] <- c(0, -2, 2, 2, 1, 0, 2)  #2l.pan
pred["popteach", ] <- c(0, -2, 2, 2, 1, 2, 0)  #2l.pan
meth <- make.method(popNCR3)
meth <- c("", "", "2l.norm", "logreg", "2lonly.mean", "2l.pan", "2l.pan")

#run mice
imp <- mice(popNCR3, pred = pred, meth = meth, print = FALSE)
```
