### PR TITLE
Skip parallel test on machine with 2 cores or less

### DIFF
--- a/tests/testthat/test-parlmice.R
+++ b/tests/testthat/test-parlmice.R
@@ -1,6 +1,7 @@
 #Same seed - multiple cores - 
 #Result: Imputations not equal between mice and parlmice
 test_that("Warning and Imputations between mice and parlmice are unequal", {
+  skip_if_not(parallel::detectCores() > 2)
   expect_warning(A <- parlmice(nhanes, m = 2, seed = 123))
   B <- mice(nhanes, m = 2, print = FALSE, seed = 123)
   expect_false(all(complete(A, "long") == complete(B, "long")))


### PR DESCRIPTION
Fixes false positive: https://github.com/r-windows/checks/blob/master/mice.Rcheck/00check.log

```
** running tests for arch 'i386' ... ERROR
  Running 'testthat.R'
Running the tests in 'tests/testthat.R' failed.
Last 13 lines of output:
  > 
  > test_check("mice")
  -- 1. Failure: Warning and Imputations between mice and parlmice are unequal (@t
  `A <- parlmice(nhanes, m = 2, seed = 123)` did not produce any warnings.
  
  -- 2. Failure: Warning and Imputations between mice and parlmice are unequal (@t
  all(complete(A, "long") == complete(B, "long")) isn't false.
  
  == testthat results  ===========================================================
  OK: 273 SKIPPED: 0 FAILED: 2
  1. Failure: Warning and Imputations between mice and parlmice are unequal (@test-parlmice.R#4) 
  2. Failure: Warning and Imputations between mice and parlmice are unequal (@test-parlmice.R#6) 
  
  Error: testthat unit tests failed
  Execution halted
```