### PR TITLE
Fixes D1 issue on Windows and (perhaps?) Solaris

### DIFF
--- a/R/D1.R
+++ b/R/D1.R
@@ -33,7 +33,11 @@ D1 <- function(fit1, fit0 = NULL, df.com = NULL, ...) {
     # better option might be pair of df.com
     # pair <- list(getfit(fit1, 1), getfit(fit0, 1))
     # df.com <- unlist(sapply(pair, glance)["df.residual", ])
-    df.com <- glance(getfit(fit1, 1))[, "df.residual"]
+    df.com <- fit1 %>%
+      getfit(1) %>%
+      glance() %>%
+      select(df.residual)%>%
+      as.numeric()
   }
   
   tmr <- testModels(fit1, fit0, method = "D1", df.com = df.com)


### PR DESCRIPTION
Fixes the following error on at least Windows:
```r
> library(broom)
> glance(getfit(B, 1))[, "df.residual"]
# A tibble: 1 x 1
  df.residual
        <int>
1          22
> D1(B, A)
Error in vapply(out, function(x) x$df.com, numeric(1)) : 
  values must be type 'double',
 but FUN(X[[1]]) result is type 'list'
```

---

**Why does this error occur?**

```r
testModels(fit1, fit0, method = "D1", df.com = df.com)
```
expects `dfcom` to be type `double`. `dfcom` is apparently not returned as class `data.frame` but as class `tibble` with type `int` on some, but not all platforms. 
