### PR TITLE
Fix 2l.norm problem for empty model 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mice
 Type: Package
-Version: 3.2.1
+Version: 3.2.2
 Title: Multivariate Imputation by Chained Equations
-Date: 2018-07-24
+Date: 2018-07-27
 Authors@R: c(person("Stef", "van Buuren", role = c("aut","cre"),
     email = "stef.vanbuuren@tno.nl"),
     person("Karin", "Groothuis-Oudshoorn", role = "aut",

--- a/R/mice.impute.2l.norm.R
+++ b/R/mice.impute.2l.norm.R
@@ -80,6 +80,7 @@ mice.impute.2l.norm <- function(y, ry, x, type, wy = NULL, intercept = TRUE, ...
     
     symridge <- function(x, ridge = 0.0001, ...) {
       x <- (x + t(x))/2
+      if (nrow(x) == 1L) return(x)
       x + diag(diag(x) * ridge)
     }
     

--- a/tests/testthat/test-D1.R
+++ b/tests/testthat/test-D1.R
@@ -11,24 +11,25 @@ empty <- with(data = imp, expr = glm(hyp == "yes" ~ 0, family = binomial))
 
 # the next tests were remove because they failed on many 
 # systems, not yet clear what the cause is (#128)
+# This is solved in #132
 
 # three new ways to compare fit1 to the intercept-only model
-# z1 <- D1(fit1, fit0)
-# z2 <- mitml::testModels(as.mitml.result(fit1), as.mitml.result(fit0), df.com = 21)
-# z3 <- D1(fit1)
+z1 <- D1(fit1, fit0)
+z2 <- mitml::testModels(as.mitml.result(fit1), as.mitml.result(fit0), df.com = 21)
+z3 <- D1(fit1)
 
-#test_that("compares fit1 to the intercept-only model", {
-#   expect_identical(z1$result, z2$test)
-#   expect_identical(z1$test, z3$test)
-#})
+test_that("compares fit1 to the intercept-only model", {
+   expect_identical(z1$result, z2$test)
+   expect_identical(z1$test, z3$test)
+})
 
 # two ways to compare fit1 to the empty model
-# z4 <- D1(fit1, empty)
-# z5 <- mitml::testModels(as.mitml.result(fit1), NULL, df.com = 21)
+z4 <- D1(fit1, empty)
+z5 <- mitml::testModels(as.mitml.result(fit1), NULL, df.com = 21)
 
-#test_that("compares fit1 to empty model", {
-#  expect_identical(z4$result, z5$test)
-#})
+test_that("compares fit1 to empty model", {
+  expect_identical(z4$result, z5$test)
+})
 
 
 context("D2")

--- a/tests/testthat/test-mice.impute.2l.norm.R
+++ b/tests/testthat/test-mice.impute.2l.norm.R
@@ -4,9 +4,7 @@ d1 <- brandsma[1:200, c("sch", "lpo")]
 pred <- make.predictorMatrix(d1)
 pred["lpo", "sch"] <- -2
 
-# OUTCOMMENTED #129
-# test_that("mice::mice.impute.2l.norm() runs empty model", {
-#   expect_silent(imp <- mice(d1, method = "2l.norm", print = FALSE, pred = pred, m = 1, maxit = 1))
-#   expect_false(anyNA(complete(imp)))
-# })
-
+test_that("mice::mice.impute.2l.norm() runs empty model", {
+  expect_silent(imp <- mice(d1, method = "2l.norm", print = FALSE, pred = pred, m = 1, maxit = 1))
+  expect_false(anyNA(complete(imp)))
+})


### PR DESCRIPTION
`mice 3.0` introduced a fix in `symridge()` in `mice.impute.2l.norm()` for the case of the empty model. However, that fix broke regular code for non-empty models. This PR introduces the correct fix that does not break regular code. 

Related:  #119, #129.
