### PR TITLE
Fixes to parlmice.R to allow it to be called from other R functions

### DIFF
--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -108,14 +108,20 @@ parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
   # create arguments to export to cluster
   args <- match.call(mice, expand.dots = TRUE)
   args[[1]] <- NULL
+  args$data <-data
   args$m <- n.imp.core
+  
+  unpackedArgs = list(...)
+  for (key in names(unpackedArgs)){
+    args[key] = unpackedArgs[key]
+  }
 
   # make computing cluster
   cl <- parallel::makeCluster(n.core, type = cl.type)
   parallel::clusterExport(cl, 
                           varlist = c("data", "m", "seed", "cluster.seed", 
                                       "n.core", "n.imp.core", "cl.type",
-                                      ls(parent.frame())), 
+                                      ls(environment(parlmice))), 
                           envir = environment())
   parallel::clusterExport(cl, 
                           varlist = "do.call")

--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -108,12 +108,13 @@ parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
   # create arguments to export to cluster
   args <- match.call(mice, expand.dots = TRUE)
   args[[1]] <- NULL
-  args$data <-data
   args$m <- n.imp.core
   
-  unpackedArgs = list(...)
-  for (key in names(unpackedArgs)){
-    args[key] = unpackedArgs[key]
+  unpackedArgs <- c(as.list(environment()), list(...))
+  for (key in names(args)){
+    if (key %in% names(unpackedArgs)){
+      args[key] = unpackedArgs[key]
+	}
   }
 
   # make computing cluster


### PR DESCRIPTION
This fix unpacks args and limits the environment passed to parallel::clusterExport.  We discovered that, without a fix like this, we were unable to call parlmice from another custom R function.